### PR TITLE
Serverpack script

### DIFF
--- a/.packwizignore
+++ b/.packwizignore
@@ -1,2 +1,3 @@
 .github/*
+serverpack/*
 README.md

--- a/index.toml
+++ b/index.toml
@@ -604,7 +604,7 @@ metafile = true
 
 [[files]]
 file = "mods/client-tweaks.pw.toml"
-hash = "4a396076c6d9fde4ea3cc9432991cbf50a6a5bf3ea74fc5ae14f720a6109f5cd"
+hash = "e45c4bda7d214e96395da66b4a7dc53d59ac46a65da529a359245ad71cd3c774"
 metafile = true
 
 [[files]]
@@ -619,7 +619,7 @@ metafile = true
 
 [[files]]
 file = "mods/controlling.pw.toml"
-hash = "f56c370b32425962d0fe4a46b16a2e62fc50dc91ab415cd6ff1ae9630bddee70"
+hash = "82ae6d431f59a49d311f0579dec737f17b064ba74969adcad50a633757cf72eb"
 metafile = true
 
 [[files]]
@@ -639,7 +639,7 @@ metafile = true
 
 [[files]]
 file = "mods/embeddium.pw.toml"
-hash = "af64183599759a2f98dc21e3b34ee1e7751f489532cdd4d2d1e873dbaadf589b"
+hash = "5a92af68349cdd4e26cd2ef2605d1fc3170ab95c0822b10d648d464f827c3594"
 metafile = true
 
 [[files]]
@@ -674,7 +674,7 @@ metafile = true
 
 [[files]]
 file = "mods/fps-reducer.pw.toml"
-hash = "f2f387a57f741e9e0a308e02f47ed8503c7eba11609fc510d1c9f6876ee9987a"
+hash = "dea4cb0ab50117d79c8c0ded39b7f4720cd5424ef88fa40d77c02a4381d9c0e1"
 metafile = true
 
 [[files]]
@@ -774,7 +774,7 @@ metafile = true
 
 [[files]]
 file = "mods/model-gap-fix.pw.toml"
-hash = "0204d84210e3d1b5ecd4460c8f5869cd1834b701f1cadf54362f5b4f66fe37d5"
+hash = "fc1540d695355081fa6c81b97d10efba751302bfbd2fb30f742551b997ac1a8f"
 metafile = true
 
 [[files]]
@@ -784,7 +784,7 @@ metafile = true
 
 [[files]]
 file = "mods/mouse-tweaks.pw.toml"
-hash = "2fbff6641656f2d2ded89f453fd42a6031e77a73a65a9516fb16477a316f7d65"
+hash = "6a72227f948c011e22e9d0b2acbe6fb59ca19a4a358e07c73f5184d63bc1d774"
 metafile = true
 
 [[files]]
@@ -819,12 +819,12 @@ metafile = true
 
 [[files]]
 file = "mods/searchables.pw.toml"
-hash = "386a4149ff03e69ad5f17e2ad7976c6e6488a92f2bd5cdf84bf653841df46bb1"
+hash = "7fc31db01aef206042287aae8e3db884fa280b7eed86d93c8c3b9d7b94934769"
 metafile = true
 
 [[files]]
 file = "mods/shimmer.pw.toml"
-hash = "bf0b75bf410eaacd0ea11592b1c112db634428bc0cc30b1bf8e73f002adc15dd"
+hash = "9a315e55de5d44fd817c72eaf02c622a97e735f7395d25f4bc8d11c541a3a34f"
 metafile = true
 
 [[files]]
@@ -869,7 +869,7 @@ metafile = true
 
 [[files]]
 file = "mods/toast-control.pw.toml"
-hash = "08d65d0ff69a3ac13cb8efb8dee95d524c285aa17201c9018c313558024832e3"
+hash = "8fc877bc846a1147efa5be974173f439d0ead4ac52ec6aa75270e2e7c32c3a32"
 metafile = true
 
 [[files]]
@@ -909,5 +909,5 @@ metafile = true
 
 [[files]]
 file = "mods/yeetusexperimentus.pw.toml"
-hash = "a50e31cc3b6ca94144aaf12d273301946717ccafe762ba7148306018d9f28267"
+hash = "cc9ecde0ae976a3ddb83540500de206c9a9694ddf66b9b8fdcba38cfe23be293"
 metafile = true

--- a/mods/client-tweaks.pw.toml
+++ b/mods/client-tweaks.pw.toml
@@ -1,6 +1,6 @@
 name = "Client Tweaks"
 filename = "clienttweaks-forge-1.20-11.1.0.jar"
-side = "both"
+side = "client"
 
 [download]
 hash-format = "sha1"

--- a/mods/controlling.pw.toml
+++ b/mods/controlling.pw.toml
@@ -1,6 +1,6 @@
 name = "Controlling"
 filename = "Controlling-forge-1.20.1-12.0.2.jar"
-side = "both"
+side = "client"
 
 [download]
 hash-format = "sha1"

--- a/mods/embeddium.pw.toml
+++ b/mods/embeddium.pw.toml
@@ -1,6 +1,6 @@
 name = "Embeddium"
 filename = "embeddium-0.2.13+mc1.20.1.jar"
-side = "both"
+side = "client"
 
 [download]
 hash-format = "sha1"

--- a/mods/fps-reducer.pw.toml
+++ b/mods/fps-reducer.pw.toml
@@ -1,6 +1,6 @@
 name = "FPS Reducer"
 filename = "FpsReducer2-forge-1.20-2.5.jar"
-side = "both"
+side = "client"
 
 [download]
 hash-format = "sha1"

--- a/mods/model-gap-fix.pw.toml
+++ b/mods/model-gap-fix.pw.toml
@@ -1,6 +1,6 @@
 name = "Model Gap Fix"
 filename = "modelfix-1.14.jar"
-side = "both"
+side = "client"
 
 [download]
 hash-format = "sha1"

--- a/mods/mouse-tweaks.pw.toml
+++ b/mods/mouse-tweaks.pw.toml
@@ -1,6 +1,6 @@
 name = "Mouse Tweaks"
 filename = "MouseTweaks-forge-mc1.20-2.25.jar"
-side = "both"
+side = "client"
 
 [download]
 hash-format = "sha1"

--- a/mods/searchables.pw.toml
+++ b/mods/searchables.pw.toml
@@ -1,6 +1,6 @@
 name = "Searchables"
 filename = "Searchables-forge-1.20.1-1.0.2.jar"
-side = "both"
+side = "client"
 
 [download]
 hash-format = "sha1"

--- a/mods/shimmer.pw.toml
+++ b/mods/shimmer.pw.toml
@@ -1,6 +1,6 @@
 name = "Shimmer"
 filename = "Shimmer-forge-1.20.1-0.2.3.jar"
-side = "both"
+side = "client"
 
 [download]
 hash-format = "sha1"

--- a/mods/toast-control.pw.toml
+++ b/mods/toast-control.pw.toml
@@ -1,6 +1,6 @@
 name = "Toast Control"
 filename = "ToastControl-1.20.1-8.0.3.jar"
-side = "both"
+side = "client"
 
 [download]
 hash-format = "sha1"

--- a/mods/yeetusexperimentus.pw.toml
+++ b/mods/yeetusexperimentus.pw.toml
@@ -1,6 +1,6 @@
 name = "Yeetus Experimentus"
 filename = "YeetusExperimentus-Forge-2.3.1-build.6+mc1.20.1.jar"
-side = "both"
+side = "client"
 
 [download]
 hash-format = "sha1"

--- a/pack.toml
+++ b/pack.toml
@@ -6,7 +6,7 @@ pack-format = "packwiz:1.1.0"
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "43f65a2798bd40212eb2f35a4fb8f6d3d25576d96b4edf2780b9bcfb01e7c5cd"
+hash = "7314f42d0495d9177802a6fd2e08a1b2f2623c942a505489c38b5ab528fff88f"
 
 [versions]
 forge = "47.2.0"

--- a/serverpack/start.sh
+++ b/serverpack/start.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+FORGE_VERSION=1.20.1-47.1.84
+
+# Ensure java is installed\
+
+if ! command -v java >/dev/null 2>&1; then
+    echo "Java 17 must be installed"
+    exit 1
+fi
+
+#Install (Neo)Forge
+
+if [ ! -f forge-1.20.1-47.1.84-installer.jar ]; then
+    curl -OJ https://maven.neoforged.net/releases/net/neoforged/forge/$FORGE_VERSION/forge-$FORGE_VERSION-installer.jar
+    java -jar forge-$FORGE_VERSION-installer.jar --installServer
+    rm run.sh run.bat
+fi
+
+# FindMe does not allow distribution on curseforge
+
+if [ ! -f mods/findme-3.1.1-forge.jar ]; then
+    mkdir mods
+    curl https://mediafilez.forgecdn.net/files/4960/678/findme-3.1.1-forge.jar -o mods/findme-3.1.1-forge.jar
+fi
+
+#Install packwiz if needed
+if [ ! -f packwiz-installer-bootstrap.jar ]; then
+    curl -OJL https://github.com/packwiz/packwiz-installer-bootstrap/releases/download/v0.0.3/packwiz-installer-bootstrap.jar
+fi
+
+java -jar packwiz-installer-bootstrap.jar -g -s server https://raw.githubusercontent.com/TacoMonkey11/GregTech-Modern-Community-Pack/fix-git-again/pack.toml
+
+java @user_jvm_args.txt @libraries/net/neoforged/forge/$FORGE_VERSION/unix_args.txt nogui


### PR DESCRIPTION
Script is not entirely no maintanence. Since FindMe disallows distribution through the api, I instead just download it directly. This means that the download link would need to change everytime the mod is updated. The forge version also would need to be updated to match the pack as well.

Everything is downloaded through the script, resulting in an extremely small initial download.

This PR also marks some clientside mods in their mod.pw.toml so that they are not downloaded on the server