### PR TITLE
Disabled AE2 channels

### DIFF
--- a/config/ae2/common.json
+++ b/config/ae2/common.json
@@ -6,7 +6,7 @@
     "tinyTntBlockDamage_comment": "Enables the ability of Tiny TNT to break blocks.",
     "tinyTntBlockDamage": true,
     "channels_comment": "Changes the channel capacity that cables provide in AE2.",
-    "channels": "default",
+    "channels": "infinite",
     "pathfindingStepsPerTick_comment": "The number of pathfinding steps that are taken per tick and per grid that is booting. Lower numbers will mean booting takes longer, but less work is done per tick.",
     "pathfindingStepsPerTick": 4,
     "spatialAnchorEnableRandomTicks_comment": "Whether Spatial Anchors should force random chunk ticks and entity spawning.",


### PR DESCRIPTION
According to 1.12 community pack I just disabled channels in AE2 however modern AE2 has different options to increase channels limit:

- **x2** for 16 and 64 channels
- **x3** for 24 and 96 channels
- **x4** for 32 and 128 channels

So we can use these options to increase this limits instead of disabling them.