### PR TITLE
Fix client-side designation

### DIFF
--- a/config/gtceu.yaml
+++ b/config/gtceu.yaml
@@ -225,7 +225,7 @@ machines:
 
   # Whether search for recipes asynchronously.
   #  Default: true
-  asyncRecipeSearching: true
+  asyncRecipeSearching: false
 
 client:
   # Whether or not to enable Emissive Textures for GregTech Machines.
@@ -320,4 +320,3 @@ dev:
   # Dump all registered GT models/blockstates/etc?
   # Default: false
   dumpAssets: false
-

--- a/index.toml
+++ b/index.toml
@@ -170,7 +170,7 @@ hash = "9abe2c7f784810cac3ca71c74d02aacd5fe6861d744cb143d077a525a2b42e76"
 
 [[files]]
 file = "config/gtceu.yaml"
-hash = "379ee4ed64eeeca5ac1374add8cedafabbfa9b785db4cce5643f2d8a3db764e0"
+hash = "e76d614de599c73e9729032156877152c662f90764875275bc41d5f06248bc41"
 
 [[files]]
 file = "config/hangglider-client.toml"
@@ -728,7 +728,7 @@ metafile = true
 
 [[files]]
 file = "mods/default-options.pw.toml"
-hash = "1cb1ed842db59e479dc2b21cf8afb8eeb9ff4577d292e6b51ed8df98e24411d5"
+hash = "bace9ac545c5db24d350a955565157500cdcedc8db6a8e78ff6118d97748eb2a"
 metafile = true
 
 [[files]]
@@ -758,7 +758,7 @@ metafile = true
 
 [[files]]
 file = "mods/ferritecore.pw.toml"
-hash = "0ad2cb032bed6c15eff1327392b16e404a9d8e787fec7c32764d142978c92583"
+hash = "5bd0506bc0be25116b234f2b5af9447f60d82ae1cb6c5be4e12d8841f6c2501c"
 metafile = true
 
 [[files]]
@@ -838,7 +838,7 @@ metafile = true
 
 [[files]]
 file = "mods/inventory-profiles-next.pw.toml"
-hash = "21964bfd2ab6c9afcdad8b2e5d873b3eeb65691d21913d21e1d6a36f4ec925db"
+hash = "1932e511c9ad771547e4b2cde97dd98e224fcd98a4ad964c612df704de3e4e91"
 metafile = true
 
 [[files]]

--- a/mods/default-options.pw.toml
+++ b/mods/default-options.pw.toml
@@ -1,6 +1,6 @@
 name = "Default Options"
 filename = "defaultoptions-forge-1.20-18.0.1.jar"
-side = "both"
+side = "client"
 
 [download]
 hash-format = "sha1"

--- a/mods/ferritecore.pw.toml
+++ b/mods/ferritecore.pw.toml
@@ -1,4 +1,4 @@
-name = "FerriteCore (Forge)"
+name = "FerriteCore ((Neo)Forge)"
 filename = "ferritecore-6.0.1-forge.jar"
 side = "both"
 

--- a/mods/inventory-profiles-next.pw.toml
+++ b/mods/inventory-profiles-next.pw.toml
@@ -1,6 +1,6 @@
 name = "Inventory Profiles Next"
 filename = "InventoryProfilesNext-forge-1.20-1.10.9.jar"
-side = "both"
+side = "client"
 
 [download]
 hash-format = "sha1"

--- a/pack.toml
+++ b/pack.toml
@@ -6,7 +6,7 @@ pack-format = "packwiz:1.1.0"
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "77f84dbfe3a31de2b359215500d36c69ce3f5a05a42f6c238bf71f0b54cddaee"
+hash = "b01bcb1424f263d4fd57fa494fcabb119c198ae16aff3c19890b22879d1c10f6"
 
 [versions]
 forge = "47.2.0"

--- a/serverpack/start.ps1
+++ b/serverpack/start.ps1
@@ -1,0 +1,129 @@
+$GAME_VERSION = "1.20.1"
+$FORGE_VERSION = "1.20.1-47.1.84"
+$FINDME_VERSION = "3.1.0"
+
+$PACK_URI = "https://raw.githubusercontent.com/GregTechCEu/GregTech-Modern-Community-Pack/main/pack.toml"
+
+# Ensure java is installed
+if (!(Get-Command java)) {
+  Write-Host -ForegroundColor Red "Java 17, which is a requirement for Minecraft, was not detected on this system."
+  Write-Host -ForegroundColor Green "On windows you can install it via the winget windows package manager by running:"
+  Write-Host -ForegroundColor Green "winget install -e --id EclipseAdoptium.Temurin.17.JRE"
+  Write-Host -ForegroundColor Green "On other systems, via your platform's package manager."
+  exit 1
+}
+
+# Install (Neo)Forge
+if (!(Test-Path "forge-$FORGE_VERSION-installer.jar")) {
+
+  $FORGE_URI = "https://maven.neoforged.net/releases/net/neoforged/forge/$FORGE_VERSION/forge-$FORGE_VERSION-installer.jar"
+
+  Write-Host -ForegroundColor Yellow "Clearing potentially incorrect versions of NeoForge..."
+  Get-ChildItem -Path ".\" -Filter "forge-*-installer.jar" | Remove-Item | Out-Null
+
+  Write-Host -ForegroundColor Blue "Fetching NeoForge Version $FORGE_VERSION"
+  Invoke-WebRequest -Uri $FORGE_URI -OutFile "forge-$FORGE_VERSION-installer.jar"
+
+  Write-Host -ForegroundColor Blue "Installing NeoForge as server, this will take a few minutes."
+
+  java -jar "forge-$FORGE_VERSION-installer.jar" --installServer 2>&1 | ForEach-Object {
+    Write-Progress -Activity "Installing NeoForge" -Status $_
+  }
+
+  if ($LASTEXITCODE -eq 0) {
+    Write-Host -ForegroundColor Green "NeoForge installation completed successfully."
+    Write-Progress -Completed -Activity "Removing progress bar."
+  } else {
+    Write-Host -ForegroundColor Red "NeoForge installation failed with exit code $LASTEXITCODE."
+    exit 1
+  }
+
+  Write-Host -ForegroundColor Yellow "Cleaning up..."
+  Remove-Item "run.sh", "run.bat" -Force
+}
+
+# FindMe does not allow distribution on curseforge
+if (!(Test-Path "mods\findme-$FINDME_VERSION-forge.jar")) {
+
+  $FINDME_ID = "rEuzehyH"
+  $FINDME_QUERY = @{
+    versions = "[`"$GAME_VERSION`"]"
+    loaders = '["forge"]'
+  }
+
+  $FINDME_DATA = Invoke-WebRequest `
+    -Uri "https://api.modrinth.com/v2/project/$FINDME_ID/version" `
+    -Body $FINDME_QUERY `
+    | ConvertFrom-Json `
+    | Where-Object { ($_.version_number.toString() -eq $FINDME_VERSION) -and $_.files.primary }
+
+  $FINDME_URI = $FINDME_DATA.files | Select-Object -first 1 -ExpandProperty url
+
+  Write-Host -ForegroundColor Yellow "Clearing potentially incorrect versions of the FindMe mod..."
+  if (Test-Path ".\mods") {
+    Get-ChildItem -Path ".\mods" -Filter "findme-*-forge.jar" | Remove-Item | Out-Null
+  }
+
+  Write-Host -ForegroundColor Blue "Fetching the FindMe mod..."
+  New-Item -ItemType Directory -Path mods -Force | Out-Null
+  Invoke-WebRequest -Uri $FINDME_URI -OutFile "mods"
+}
+
+# Install packwiz-installer-bootstrap if needed.
+if (!(Test-Path "packwiz-installer-bootstrap.jar")) {
+
+  Write-Host -ForegroundColor Yellow "Finding the latest packwiz-installer-bootstrap release..."
+  $BOOTSTRAP_RELEASES = "https://api.github.com/repos/packwiz/packwiz-installer-bootstrap/releases/latest"
+  $BOOTSTRAP_URI = Invoke-WebRequest $BOOTSTRAP_RELEASES `
+  | ConvertFrom-Json `
+  | Select-Object -Property assets `
+  | ForEach-Object { $_.assets.browser_download_url } `
+  | Select-Object -first 1
+
+  Write-Host -ForegroundColor Blue "Fetching the packwiz-installer-bootstrap..."
+  Invoke-WebRequest -Uri $BOOTSTRAP_URI -OutFile "packwiz-installer-bootstrap.jar"
+
+}
+
+# Use packwiz-installer-bootstrap to generate or update the modpack.
+Write-Host -ForegroundColor Magenta "Updating the server pack..."
+java -jar "packwiz-installer-bootstrap.jar" -g -s server $PACK_URI 2>&1 | ForEach-Object {
+  Write-Progress -Activity "Installing mods and related files" -Status $_
+}
+
+if ($LASTEXITCODE -eq 0) {
+  Write-Host -ForegroundColor Green "Server installation/update complete."
+  Write-Progress -Completed -Activity "Removing progress bar."
+} else {
+  Write-Host -ForegroundColor Red "Server installation/update failed with exit code $LASTEXITCODE."
+  exit 1
+}
+
+
+# Inform about the EULA and either force agree or exit.
+if (!(Test-Path "eula.txt") -or (Get-Content eula.txt | ConvertFrom-StringData).eula) {
+  Write-Host -ForegroundColor Yellow "In order to run a Minecraft server, you need to agree to the Minecraft EULA."
+  Write-Host -ForegroundColor Yellow "You can read the Minecraft EULA here: https://aka.ms/MinecraftEULA"
+  Write-Host -ForegroundColor Yellow "For your convenience, this script can automatically agree for you."
+  Write-Host -ForegroundColor Yellow 'By choosing "Yes" you are assuming full responsibility for agreeing to the EULA.'
+
+  $EULA_QUESTION = "Would you like for this script to agree to the Minecraft EULA in your stead?"
+  $EULA_DECISION = $Host.UI.PromptForChoice('Minecraft EULA Agreement', $EULA_QUESTION, @('&Yes'; '&No'), 1)
+  if ($EULA_DECISION -eq 0) {
+    Write-Host -ForegroundColor Yellow "Agreeing to the EULA per the users choice..."
+    Set-Content -Path "eula.txt" -Value "eula=true"
+  } else {
+    Write-Host -ForegroundColor Red "User won't accept the EULA, exiting..."
+    exit 1
+  }
+}
+
+# Run the server
+if ($PSVersionTable.Platform.startsWith("Win")) {
+  $PLATFORM_ARGS = "win_args.txt"
+} else {
+  $PLATFORM_ARGS = "unix_args.txt"
+}
+
+Write-Host "Running the server..."
+java @( "@user_jvm_args.txt", "@libraries/net/neoforged/forge/$FORGE_VERSION/$PLATFORM_ARGS" ) nogui %*

--- a/serverpack/start.ps1
+++ b/serverpack/start.ps1
@@ -47,7 +47,7 @@ if (!(Test-Path "mods\findme-$FINDME_VERSION-forge.jar")) {
 
   $FINDME_ID = "rEuzehyH"
   $FINDME_QUERY = @{
-    versions = "[`"$GAME_VERSION`"]"
+    "game_versions" = "[`"$GAME_VERSION`"]"
     loaders = '["forge"]'
   }
 

--- a/serverpack/start.sh
+++ b/serverpack/start.sh
@@ -11,7 +11,7 @@ fi
 # Function to download with either curl or wget
 download() {
     if command -v curl >/dev/null 2>&1; then
-        curl -OJ "$1"
+        curl -OJL "$1"
     elif command -v wget >/dev/null 2>&1; then
         wget "$1"
     else

--- a/serverpack/start.sh
+++ b/serverpack/start.sh
@@ -2,31 +2,40 @@
 
 FORGE_VERSION=1.20.1-47.1.84
 
-# Ensure java is installed\
-
+# Ensure java is installed
 if ! command -v java >/dev/null 2>&1; then
     echo "Java 17 must be installed"
     exit 1
 fi
 
-#Install (Neo)Forge
+# Function to download with either curl or wget
+download() {
+    if command -v curl >/dev/null 2>&1; then
+        curl -OJ "$1"
+    elif command -v wget >/dev/null 2>&1; then
+        wget "$1"
+    else
+        echo "Neither curl nor wget found. Please install either curl or wget."
+        exit 1
+    fi
+}
 
-if [ ! -f forge-1.20.1-47.1.84-installer.jar ]; then
-    curl -OJ https://maven.neoforged.net/releases/net/neoforged/forge/$FORGE_VERSION/forge-$FORGE_VERSION-installer.jar
+# Install (Neo)Forge
+if [ ! -f forge-$FORGE_VERSION-installer.jar ]; then
+    download "https://maven.neoforged.net/releases/net/neoforged/forge/$FORGE_VERSION/forge-$FORGE_VERSION-installer.jar"
     java -jar forge-$FORGE_VERSION-installer.jar --installServer
     rm run.sh run.bat
 fi
 
 # FindMe does not allow distribution on curseforge
-
 if [ ! -f mods/findme-3.1.1-forge.jar ]; then
-    mkdir mods
-    curl https://mediafilez.forgecdn.net/files/4960/678/findme-3.1.1-forge.jar -o mods/findme-3.1.1-forge.jar
+    mkdir -p mods
+    download "https://mediafilez.forgecdn.net/files/4960/678/findme-3.1.1-forge.jar" -O mods/findme-3.1.1-forge.jar
 fi
 
-#Install packwiz if needed
+# Install packwiz if needed
 if [ ! -f packwiz-installer-bootstrap.jar ]; then
-    curl -OJL https://github.com/packwiz/packwiz-installer-bootstrap/releases/download/v0.0.3/packwiz-installer-bootstrap.jar
+    download "https://github.com/packwiz/packwiz-installer-bootstrap/releases/download/v0.0.3/packwiz-installer-bootstrap.jar"
 fi
 
 java -jar packwiz-installer-bootstrap.jar -g -s server https://raw.githubusercontent.com/GregTechCEu/GregTech-Modern-Community-Pack/main/pack.toml

--- a/serverpack/start.sh
+++ b/serverpack/start.sh
@@ -29,6 +29,6 @@ if [ ! -f packwiz-installer-bootstrap.jar ]; then
     curl -OJL https://github.com/packwiz/packwiz-installer-bootstrap/releases/download/v0.0.3/packwiz-installer-bootstrap.jar
 fi
 
-java -jar packwiz-installer-bootstrap.jar -g -s server https://raw.githubusercontent.com/TacoMonkey11/GregTech-Modern-Community-Pack/fix-git-again/pack.toml
+java -jar packwiz-installer-bootstrap.jar -g -s server https://raw.githubusercontent.com/GregTechCEu/GregTech-Modern-Community-Pack/main/pack.toml
 
 java @user_jvm_args.txt @libraries/net/neoforged/forge/$FORGE_VERSION/unix_args.txt nogui


### PR DESCRIPTION
Both Inventory Profiles Next and Default Options are client-side mods and should be marked so for correctly building server packs with packwiz-installer-bootstrap. The FerriteCore edit is only to match its name on curseforge. Also disabled asyncRecipeSearching so that multiblocks can work correctly again.