### PR TITLE
Fix Better Tag NBT Tips server crash

### DIFF
--- a/mods/better-tips-nbt-tag.pw.toml
+++ b/mods/better-tips-nbt-tag.pw.toml
@@ -1,6 +1,6 @@
 name = "Better Tag NBT Tips"
 filename = "BetterTags-1.20.1-1.1.jar"
-side = "both"
+side = "client"
 
 [download]
 hash-format = "sha1"


### PR DESCRIPTION
I am hosting a server on Pebblehost with this modpack. The following error prevented the server from starting:

```text
09.07 15:05:24 [Server] INFO Caused by: java.lang.UnsatisfiedLinkError: /usr/local/pebblej17/lib/libawt_xawt.so: libXext.so.6: cannot open shared object file: No such file or directory
```

([full log](https://mcpaste.io/05ac12110a75f4bb))

Removing the Better Tag NBT Tips fixed the issue. The `libXext` library is related to the X11 window system so I assume the error happened because Better Tag NBT Tips is a client-side mod.

This PR changes Better Tag NBT Tips to be a client-side mod.