### PR TITLE
Fixing the fire resistance potion shapeless crafting

### DIFF
--- a/kubejs/server_scripts/vanilla/vanilla.js
+++ b/kubejs/server_scripts/vanilla/vanilla.js
@@ -82,7 +82,7 @@ ServerEvents.recipes((event) => {
     [
       Item.of("minecraft:potion").withNBT({
         Potion: "minecraft:water",
-      }),
+      }).strongNBT(),
       "#forge:dusts/sugar",
       "#forge:dusts/stone",
       "#forge:dusts/lead",
@@ -95,7 +95,7 @@ ServerEvents.recipes((event) => {
     [
       Item.of("minecraft:potion").withNBT({
         Potion: "minecraft:water",
-      }),
+      }).strongNBT(),
       "#forge:dusts/redstone",
       "#forge:dusts/sugar",
       "#forge:dusts/stone",


### PR DESCRIPTION
made it so it only only takes in water potions, rather than any potion, also leading to broken JEI display.
before:
![image](https://github.com/user-attachments/assets/8479511d-0d06-47bf-a1a8-9e127787726e)
now it only works with water potions :)