### PR TITLE
Fixing the "Zane" craft

### DIFF
--- a/kubejs/server_scripts/building/xtones.js
+++ b/kubejs/server_scripts/building/xtones.js
@@ -69,7 +69,7 @@ ServerEvents.recipes((event) => {
   createRecipe("#forge:dyes/gray", "tank")
   createRecipe("#forge:dyes/black", "vect")
   createRecipe("#forge:dyes/light_blue", "vena")
-  createRecipe("#forge:dusts/clay", "zane")
+  createRecipe("#forge:ingots/clay", "zane")
   createRecipe("#forge:dusts/iron", "zech")
   createRecipe("snowball", "zest")
   createRecipe("string", "zeta")


### PR DESCRIPTION
For now there is a duplication in crafts of building blocks
![image](https://github.com/user-attachments/assets/b779ab0f-fba9-489b-b3bf-f80b08b83392)
![image](https://github.com/user-attachments/assets/6d5a1eb3-2290-42a9-9af0-763328140fd1)

I suggest changing zane recipe to use clay ball
![image](https://github.com/user-attachments/assets/702bc224-ea88-4b88-aba7-5daaf8155957)
