### PR TITLE
Quest Changes

### DIFF
--- a/config/ftbquests/quests/chapters/gtceu.snbt
+++ b/config/ftbquests/quests/chapters/gtceu.snbt
@@ -149,13 +149,13 @@
 			description: [
 				"The ore generation in &2GregTech&r is very different to vanilla or normal modded Minecraft. All ores generate in &6huge veins&r, which can contain &dhundreds&o&r of ore blocks."
 				""
-				"GTCEu now features the functionality of &dVisual Prospecting&r natively, which will mark discovered veins on your map. &9Right Click&r an ore block in the vein to add it to the map. You can toggle the ore vein view in the lower left corner of the fullscreen map."
+				"GTCEu now features the functionality of &dVisual Prospecting&r natively, which will mark discovered veins on your map. &9Right Click&r an ore block in the vein, or a surface rock to add it to the map. You can toggle the ore vein view in the lower left corner of the fullscreen map."
 				"{@pagebreak}"
 				"The full extent of ore generation is explained in the Tips and Tricks tab, but here is what you need to know:"
 				""
 				"&9-&r Ore veins generate in a &4Grid&r. Every vein is &9spaced by (approximately) 3 chunks&r from one to another in a cardinal direction."
 				""
-				"&9-&r It's a good practice to make &dWaypoints&r (default &4N&r) for every vein you find, and to label their type. You may want to come back to the vein several times."
+				"&9-&r It's a good practice to make &dWaypoints&r (default &4N&r) for the veins you're currently mining through, and to label their type. You may want to come back to the vein several times."
 			]
 			icon: "gtceu:cobaltite_ore"
 			id: "0C690272ED4FB1C3"
@@ -770,6 +770,8 @@
 				""
 				"If you're familiar with &a&lTinker's Construct&r, it behaves &esimilarly&r to hammers from that mod."
 				""
+				"Shift-right-click with a mining hammer in your hand to adjust the destruction size."
+				""
 				"Make &bgood use&r of these hammers! They'll help you to clear out an entire vein in &6record time&r."
 				""
 				"&eNote:&r Any quest with GregTech tools can be complete with tools crafted from any material - not just the one displayed."
@@ -833,8 +835,8 @@
 			id: "1ECBA1CBFFB9F625"
 			rewards: [{
 				count: 32
-				id: "5CD664F60E977214"
-				item: "gtceu:magnetite_ore"
+				id: "6A8A7B57C7372740"
+				item: "gtceu:raw_magnetite"
 				type: "item"
 			}]
 			size: 0.75d
@@ -1081,6 +1083,8 @@
 				"The Hatch allows for automation - it'll &dauto-export&r both Fluid and Items! It also works for insertion into the Coke Oven (you can use Hoppers)."
 				""
 				"If the Coke Oven happens to fully fill up on &eCreosote&r that you are not using, break and replace the Coke Oven block. &3Automated fluid voiding&r is available later in the game."
+				""
+				"&lTip:&r A bucket of Creosote fuels a furnace for &c32&r items! Take full advantage of this to stop burning planks."
 				"{@pagebreak}"
 				"&l&3Lore:&r&o The concept of multiblocks is a modded Minecraft classic. Think of IC2's Nuclear Reactor, or Railcraft's Coke Oven - truly revolutionary at the time!&r"
 			]
@@ -1155,7 +1159,7 @@
 			description: [
 				"&6Bronze&r is an &2alloy&r of Copper and Tin. Grind down 3 parts Copper and 1 part Tin into dust, then combine and smelt them. If you are confused on how this is done, take a look at the &o\"&dMore Tools&r&o\"&r quest."
 				""
-				"Aim to make &amany more&r Bronze Ingots than is called for here. This is the main material for the &6Steam Age&r, and you will need LOTS of it."
+				"Don't spend your entire supply of Copper and Tin on Bronze right now! You'll soon be able to get a better ratio for your Bronze."
 				""
 				"&6&lThe progression now continues in the Steam Age chapter.&r"
 				"{@pagebreak}"
@@ -1170,7 +1174,7 @@
 				type: "item"
 			}]
 			shape: "gear"
-			size: 1.3d
+			size: 1.2d
 			subtitle: "Humanity's first alloy - and yours too!"
 			tasks: [{
 				count: 24L
@@ -1267,7 +1271,7 @@
 				""
 				"If you're playing solo, feel free to &aadd mods&r to your instance. Some more &bQoL&r could be nice... more &3Tech&r could sate your cravings... maybe even some &5magic mods&r, as long as you don't add &eProjectE&r. Promise?"
 				""
-				"On the 1.12.2 version of &aGregtech: CEu&r, there were multiple &aGregTech&r addons that may be ported to 1.19.2 in future. Rest assured that this pack will do its &dbest&r to support them if they make it to this version!"
+				"On the 1.12.2 version of &aGregtech: CEu&r, there were multiple &aGregTech&r addons that may be ported to 1.20.1 in future. Rest assured that this pack will do its &dbest&r to support them if they make it to this version!"
 			]
 			icon: "minecraft:structure_void"
 			id: "1283B4D7B5D82193"
@@ -1580,7 +1584,12 @@
 				""
 				"We've gathered some GTCEu Modern-flavored recommendations in this quest."
 				"{@pagebreak}"
-				"&lCosmic Frontiers"
+				"&lMonifactory&r"
+				"&dMonifactory&r is a 1.20.1 modpack based on &eNomifactory CEu&r (which was on 1.12.2!). It aims to streamline and simplify the earlier parts of GregTech, while interweaving other tech mods into GTCEu Modern's progression. It also features a &2Hard&r and an &aExpert&r mode for the challenge-minded!"
+				""
+				"In its current state, the pack is on the cusp of a pack-changing update, 0.13. Any worlds at &cHigh Voltage&r or higher will likely need a fresh restart."
+				"{@pagebreak}"
+				"&lCosmic Frontiers&r"
 				"- &7Ghostipedia et al."
 				""
 				"&dCosmic Frontiers&r is a 1.20.1 modpack with gameplay &ba little more difficult&r than this pack, and a focus on interactions between many mods and GTCEu Modern. You'll explore the stars above and travel to the depths below, all whilst tackling &eintricately woven&r progression that ties together the &7mechanical&r and the &5arcane&r."
@@ -1601,7 +1610,9 @@
 				""
 				"Progression in this pack will take you above and beyond &3UHV&r, with numerous unique &aStargates&r to craft, and even a remixed &o\"Gregified\"&r Mystical Agriculture."
 				""
-				"Note that the pack is still under &eheavy development&r, but you should be able to achieve the &o\"Classic Stargate\"&r as of version BETA 1!"
+				"Once again, this pack features a Hard mode, and a Desert mod (called Abydos!)."
+				""
+				"Note that the pack is still under &eheavy development&r, but you should be able to achieve the &o\"Classic Stargate\"&r as of version Zeta!"
 			]
 			icon: "minecraft:netherite_upgrade_smithing_template"
 			id: "63DC162144871509"

--- a/config/ftbquests/quests/chapters/hv__high_voltage.snbt
+++ b/config/ftbquests/quests/chapters/hv__high_voltage.snbt
@@ -1,4 +1,5 @@
 {
+	autofocus_id: "42FB276AB16258D9"
 	default_hide_dependency_lines: false
 	default_quest_shape: ""
 	filename: "hv__high_voltage"
@@ -129,24 +130,34 @@
 		{
 			dependencies: ["26394C1290D70AB6"]
 			description: [
-				"If you're &lstill&r running off the &3Large Bronze Boiler&r, you may want to upgrade to the &3Large Steel Boiler&r."
+				"If you're &lstill&r running off the &3Large Bronze Boiler&r, you may &o(read: may not)&r want to upgrade to the &3Large Steel Boiler&r."
 				""
-				"It's slightly more efficient than the &3LBB&r, and produces &d900 EU/t worth of Steam&r."
+				"It's slightly more efficient than the &3LBB&r, and produces &d900 EU/t worth of Steam&r..."
 				""
 				"We'd politely recommend that you try other power options at this point."
+				""
+				"Anyway, here's a checkmark to skip the quest."
 			]
 			icon: "gtceu:steel_large_boiler"
 			id: "1BB40CCF17D00719"
 			shape: "rsquare"
 			size: 0.66d
 			subtitle: "Steam isn't the only answer, but we won't stop you"
-			tasks: [{
-				id: "3872B1D118426B33"
-				item: "gtceu:steel_large_boiler"
-				type: "item"
-			}]
+			tasks: [
+				{
+					id: "3872B1D118426B33"
+					item: "gtceu:steel_large_boiler"
+					optional_task: true
+					type: "item"
+				}
+				{
+					id: "5665BED547B49DAB"
+					title: "I am sane."
+					type: "checkmark"
+				}
+			]
 			title: "One Hundred Million Pressure Cookers"
-			x: 1.125d
+			x: 0.0d
 			y: -0.75d
 		}
 		{
@@ -248,8 +259,8 @@
 				}
 			]
 			title: "We call this \"fun\""
-			x: 0.0d
-			y: -1.875d
+			x: 1.125d
+			y: -0.75d
 		}
 		{
 			dependencies: [
@@ -275,6 +286,8 @@
 				"Time to say goodbye to your &4Primitive Water Pumps&r. They've done you proud."
 				""
 				"Place this on the side of a machine to give it &616 buckets&o&r&r of Water every second!"
+				""
+				"Later on in &5EV&r, you can use these to craft Infinite Water Cells for your AE2 network."
 			]
 			icon: "gtceu:infinite_water_cover"
 			id: "78464574AF8A27AC"
@@ -287,7 +300,7 @@
 				type: "item"
 			}]
 			title: "Infinite Water"
-			x: 2.25d
+			x: 1.125d
 			y: 0.375d
 		}
 		{
@@ -368,7 +381,7 @@
 			}]
 			title: "Digital Fluid Storage"
 			x: 3.375d
-			y: -0.75d
+			y: 0.375d
 		}
 		{
 			dependencies: [
@@ -523,8 +536,8 @@
 				type: "item"
 			}]
 			title: "HV Superconductors"
-			x: 4.5d
-			y: -4.125d
+			x: 5.625d
+			y: -6.375d
 		}
 		{
 			dependencies: [
@@ -550,8 +563,8 @@
 				type: "item"
 			}]
 			title: "Nichrome Coils"
-			x: 4.5d
-			y: -5.25d
+			x: 6.75d
+			y: -6.375d
 		}
 		{
 			dependencies: [
@@ -576,7 +589,7 @@
 				type: "choice"
 			}]
 			shape: "gear"
-			size: 1.2d
+			size: 1.0d
 			subtitle: "Titanite Slab"
 			tasks: [{
 				id: "6D3E269567F419DE"
@@ -618,8 +631,8 @@
 				type: "item"
 			}]
 			title: "300IQ"
-			x: 3.375d
-			y: -5.25d
+			x: 7.875d
+			y: -6.375d
 		}
 		{
 			dependencies: ["4AFD3073C731A1E4"]
@@ -648,7 +661,7 @@
 				"1C55AE6AD5BDE304"
 				"6958029B5514D4EC"
 			]
-			description: ["&a4A&r of &bMV&r energy transmission may be appealing, but you probably don't need these at this point. The option is always there if you need it."]
+			description: ["&a4A&r of &bMV&r energy transmission may be appealing, but you probably don't need these at this point. Frankly, you might find it easier to just jump straight to the &6HV&r Superconductors. The option is always there if you need it. Boron can be obtained as a Salt processing byproduct."]
 			icon: "gtceu:magnesium_diboride_double_wire"
 			id: "72F0DFAF5CC6D0FE"
 			shape: "rsquare"
@@ -1275,7 +1288,7 @@
 				}
 			]
 			title: "SMD Components"
-			x: 3.375d
+			x: 2.25d
 			y: 0.375d
 		}
 		{
@@ -1301,7 +1314,7 @@
 				}
 			]
 			title: "More SMD Components"
-			x: 3.375d
+			x: 2.25d
 			y: 1.5d
 		}
 		{
@@ -1327,7 +1340,7 @@
 				type: "item"
 			}]
 			title: "Universal Macerator"
-			x: -1.125d
+			x: 0.0d
 			y: -1.875d
 		}
 		{

--- a/config/ftbquests/quests/chapters/lv__low_voltage.snbt
+++ b/config/ftbquests/quests/chapters/lv__low_voltage.snbt
@@ -344,7 +344,7 @@
 				""
 				"The &7Front Face&r should be obvious.\\nThe &9Output Face&r is the face with a dot or hole on it. By default, this is at the back of the machine as you place it."
 				""
-				"Machines can &aauto-output&r through their output face. To enable auto-output, click the appropriate button in the GUI. Fluid and item auto-outputs are toggled separately. Further control over auto-outputs can be achieved with &dFilters&r and &dCovers&r, which are explained in the quest to the upper left of this one."
+				"Machines can &aauto-output&r through their output face. To enable auto-output, click the appropriate button in the GUI. Fluid and item auto-outputs are toggled separately. Further control over outputs can be achieved with &dFilters&r and &dCovers&r, which are explained in the quest to the upper left of this one."
 				"{@pagebreak}"
 				"Right-clicking a machine with a &5Wrench&r changes the output side, and shift-right-clicking changes the front side. Keep in mind that the front side &ccannot&r also be the output side! "
 				""
@@ -374,7 +374,7 @@
 			description: [
 				"You could make any other &7LV&r Machine, but it would be easiest to start with the most useful one. We know, we know... you wanna make some of the crazier stuff first, but trust us, this is the best starting point."
 				""
-				"The Wiremill lets you make &6two Wires from one Ingot&r. That should be three times cheaper than what you were doing up until now!"
+				"The Wiremill lets you make &6two Wires from one Ingot&r. That should be three times cheaper than what you were doing up until now! &8&oPlus, aren't you sick of crafting Wire Cutters?&r&r"
 				""
 				"To the right of this Quest, you'll find some important machines which will grant you cheaper intermediates."
 				"{@pagebreak}"
@@ -484,7 +484,7 @@
 			description: [
 				"&dSneak right-click&r when in hand to activate your Magnet. Do it again to deactivate. The battery capacity of your magnet depends on the battery used to craft it."
 				""
-				"&9Note:&r If you're worried about getting overwhelmed by Cobblestone or Netherrack, use the trash can from FTB Utilities (top left corner of your inventory) to void them."
+				"Note that the magnet has a whitelist filter turned on by default (in other words, it's not going to pick anything up.) Right-click the magnet to tinker with the item filter settings. There's even a &ctag filter&r - you could, for example, whitelist only &braw ores&r!"
 			]
 			id: "3ECD9C9B909CCCCC"
 			shape: "rsquare"
@@ -506,7 +506,7 @@
 				""
 				"If you want Steam-based power production, this will be your first port-of-call. Other power options are listed in the &bMV&r chapter."
 				""
-				"We should note that the LBB in its &bcurrent state&r isn't... great. It's probably better to use an alternate fuel source for now (or just spam &dsingleblock Boilers&r). This will be &2rebalanced&r in due time, don't you worry."
+				"We should note that the LBB in its &bcurrent state&r isn't... great. It's probably better to use an alternate fuel source for now (or just spam &dsingleblock Boilers&r). This will be &2rebalanced&r in due time, don't you worry. For that reason, though, you can &cskip this quest&r with the checkmark."
 				""
 				"&cImportant:&r This Boiler &lCAN&r also &cexplode&r similarly to the regular Boilers! Usually, the explosion can be rather devastating... but it's configured to not damage blocks or entities in this modpack."
 				"{@pagebreak}"
@@ -518,6 +518,7 @@
 				""
 				"&9Note:&r An in-depth tutorial about Multiblocks is given after you get the &3Electric Blast Furnace&r. We recommend you aim for that first."
 			]
+			icon: "gtceu:bronze_large_boiler"
 			id: "33263404ED38C6D2"
 			rewards: [{
 				id: "1BEF1D97E033F1B1"
@@ -527,11 +528,19 @@
 			shape: "square"
 			size: 0.75d
 			subtitle: "Boom, boom, boom, boom"
-			tasks: [{
-				id: "560D4D0D6BECE006"
-				item: "gtceu:bronze_large_boiler"
-				type: "item"
-			}]
+			tasks: [
+				{
+					id: "560D4D0D6BECE006"
+					item: "gtceu:bronze_large_boiler"
+					optional_task: true
+					type: "item"
+				}
+				{
+					id: "49958803B3B2E387"
+					title: "Yeah, I'll pass..."
+					type: "checkmark"
+				}
+			]
 			x: 6.75d
 			y: 2.25d
 		}
@@ -545,6 +554,9 @@
 				"If you weren't already enamoured, the 1x variant also covers 2 Amps. Isn't that nice?"
 				""
 				"Now is a good time to replace your crappy &aTin Cables&r. Recycle them in the &3Packager&r to recover both the Tin and Rubber used to craft them."
+				"{@pagebreak}"
+				"Can't figure out how to make some of these? Here's a hint - &eTricalcium Phosphate&r and &2Pyrolusite&r ought to help."
+				""
 				"{@pagebreak}"
 				"&l&3Lore:&r&o No version of GregTech has had actual Superconductors for &7LV&f up until Gregicality and GTCEu, though some modpacks had lossless cables."
 			]
@@ -576,6 +588,7 @@
 				""
 				"&oIn GTCE, the Thermal Centrifuge was changed to only work at &bMV&f with 60EU/t recipes. Let's be completely honest with you... what a &4complete waste of time&f! Never worth it. Thankfully, we've buffed the machine to be much more relevant."
 			]
+			hide_dependent_lines: true
 			id: "772F7CD63D31966A"
 			size: 0.75d
 			subtitle: "No, not THAT kind of Thermal"
@@ -670,6 +683,8 @@
 				""
 				"This is a \"&7fake circuit&r\" that allows you to select a configuration for recipes. There's no need to spend your circuits crafting &bProgrammed Circuits&r anymore."
 				""
+				"The purpose of this ghost circuit is to prevent &drecipe clashes&r - for example, the same Wiremill can produce wires of different thicknesses, with the same material!"
+				""
 				"&dElectric Machines&r and &dItem Input Buses&r will have a Ghost Circuit Slot."
 				"{@pagebreak}"
 				"&l&3Lore:&r&o This feature is originally from GTNH."
@@ -690,7 +705,7 @@
 				type: "checkmark"
 			}]
 			title: "Programmed Circuits"
-			x: 3.3d
+			x: 3.375d
 			y: 1.98d
 		}
 		{
@@ -760,6 +775,8 @@
 				"By itself, the Battery Buffer does nothing. However, if you place batteries inside its internal storage, it will act as a power buffer."
 				""
 				"The &3Battery Buffer&r handles &9two Amps in&r, and &9one Amp out&r, &dper Battery&r. The output side has the dot, and all other sides are used as inputs."
+				""
+				"Our recommendation is to have your generators input energy into it, and power your machines from the output side. This is because the Battery Buffers will demand many Amps of power when it charges, and this could prevent you from using your other machines if it's set up in a way where it can divert power from your other machines to itself."
 				""
 				"&6It'll also charge &lboth&r EU and RF Tools inside it&r."
 				""
@@ -895,7 +912,9 @@
 		{
 			dependencies: ["32EA7E81885C8E87"]
 			description: [
-				"&7LV&r will require you to craft a lot of different machines! Here's a friendly tip if you're struggling to set goals: pick an item in a later quest and go backwards from there."
+				"&7LV&r will require you to craft a lot of different machines! You may also find it useful to have multiple of the same machine, set to different programmed circuit values."
+				""
+				"Here's a friendly tip if you're struggling to set goals: pick an item in a later quest and go backwards from there."
 				""
 				"With that in mind... why don't we start with a &5Fusion Reactor&r? Never mind, slightly too ambitious - let's check a closer goal instead. Ah, yes, the &3Electric Blast Furnace&r - the main \"end goal\" of &7LV&r - should be a good target."
 				""
@@ -919,6 +938,7 @@
 		}
 		{
 			dependencies: ["3D98819A799D2E64"]
+			dependency_requirement: "one_completed"
 			description: [
 				"Build this machine next to your &3Chemical Reactor&r to automatically solidify Rubber into &aRubber Sheets&r."
 				""
@@ -1046,15 +1066,18 @@
 			y: 3.375d
 		}
 		{
-			dependencies: ["3A8D7FC6F316C38C"]
+			dependencies: [
+				"3A8D7FC6F316C38C"
+				"5263F866638D875C"
+			]
 			description: [
 				"The Gas Collector collects Air that can then be centrifuged into &aOxygen&r and &aNitrogen&r."
 				""
 				"&l&3Lore:&r&o GregTech 5 players remember when they had to use a Compressor with IC2 cells to get Compressed Air... here, cell chemistry is no more."
 			]
 			id: "15928F50AE80A5CF"
-			shape: "rsquare"
-			size: 0.66d
+			shape: "square"
+			size: 0.75d
 			subtitle: "Time to sell some Air"
 			tasks: [{
 				id: "5710E0C2A7441809"
@@ -1062,7 +1085,7 @@
 				type: "item"
 			}]
 			title: "Basic Gas Collector"
-			x: 1.125d
+			x: -1.125d
 			y: 6.75d
 		}
 		{
@@ -1127,10 +1150,10 @@
 			]
 			title: "Basic Chemical Reactor"
 			x: 3.375d
-			y: 5.625d
+			y: 4.5d
 		}
 		{
-			dependencies: ["3D98819A799D2E64"]
+			dependencies: ["10ECB471A77F5136"]
 			description: [
 				"Cells are an alternative form of Fluid storage. All Cell types with the same type and amount of Fluid inside them &6stack&r. They can be automatically filled with a &3Canning Machine&r."
 				""
@@ -1142,6 +1165,7 @@
 				""
 				"Like Drums, Cells can be placed into a crafting grid to clear their contents."
 			]
+			hide_dependency_lines: true
 			icon: "gtceu:fluid_cell"
 			id: "292938760AB9A12B"
 			rewards: [{
@@ -1167,7 +1191,7 @@
 			]
 			title: "Dead Cells"
 			x: 4.5d
-			y: 5.625d
+			y: 5.61d
 		}
 		{
 			dependencies: [
@@ -1179,7 +1203,7 @@
 				""
 				"You can also do the same for &6Gears&r and &6Small Gears&r, which will then be superseded when you make a &3MV Extruder&r."
 				""
-				"&9Note:&r Some metals require higher voltages than &7LV&r for Fluid Extraction, so make sure to keep an eye on the recipe tier in EMI."
+				"&9Note:&r Some metals, like Steel, require higher voltages than &7LV&r for Fluid Extraction, so make sure to keep an eye on the recipe tier in EMI."
 			]
 			icon: "gtceu:rotor_casting_mold"
 			id: "115C4226F6473F0C"
@@ -1207,7 +1231,7 @@
 			]
 			title: "C-C-Combo!"
 			x: 5.625d
-			y: 5.625d
+			y: 4.5d
 		}
 		{
 			dependencies: ["199361B5FEC959EA"]
@@ -1216,10 +1240,11 @@
 				""
 				"The choice is yours. Save more materials? Make Soldering Alloy. Spend less time crafting materials? Tin is the way to go."
 			]
+			hide_dependent_lines: true
 			icon: "gtceu:soldering_alloy_ingot"
 			id: "713C8D6A20BF3A0E"
-			shape: "rsquare"
-			size: 0.66d
+			shape: "square"
+			size: 0.75d
 			subtitle: "I got soul but I'm not a solder"
 			tasks: [{
 				id: "67F9F84D66E32728"
@@ -1227,8 +1252,8 @@
 				type: "item"
 			}]
 			title: "Soldering Alloy"
-			x: 7.875d
-			y: 5.625d
+			x: 5.625d
+			y: 9.0d
 		}
 		{
 			dependencies: [
@@ -1303,10 +1328,12 @@
 		}
 		{
 			dependencies: [
-				"5263F866638D875C"
-				"2F1CCFEBAB71B1F3"
+				"257DB4B39B2A928E"
+				"45B71324028F6E68"
 			]
 			description: [
+				"If you haven't made a &eMixer&r yet, you'll need it to craft this."
+				""
 				"For now, you should use &9Water&r for its recipes instead of trying to acquire Lubricant."
 				""
 				"The &3Cutting Machine&r additionally unlocks converting &6Rods into four Bolts&r."
@@ -1314,8 +1341,8 @@
 				"This machine is the only way to obtain &dGem Plates&r, which are needed to craft Filters, and by extension, the &3Gas Collector&r."
 			]
 			id: "3A8D7FC6F316C38C"
-			shape: "rsquare"
-			size: 0.66d
+			shape: "square"
+			size: 0.75d
 			subtitle: "The Cutter... cuts..."
 			tasks: [{
 				id: "662DB818821C4EAE"
@@ -1323,7 +1350,7 @@
 				type: "item"
 			}]
 			title: "Basic Cutter"
-			x: -1.125d
+			x: 1.125d
 			y: 6.75d
 		}
 		{
@@ -1381,7 +1408,7 @@
 			dependencies: [
 				"63CD0236B337EAAD"
 				"37307A46E70011D3"
-				"3D98819A799D2E64"
+				"292938760AB9A12B"
 			]
 			description: [
 				"Unfortunately, this is only an &lEmpty&r Spray Can, which you have to fill with Chemical Dye before using."
@@ -1403,7 +1430,7 @@
 			}]
 			title: "Spray Can"
 			x: 3.375d
-			y: 6.75d
+			y: 5.625d
 		}
 		{
 			dependencies: ["648BCF486E16CCB2"]
@@ -1448,13 +1475,13 @@
 				item: "gtceu:lv_assembler"
 				type: "item"
 			}]
-			x: 4.5d
+			x: 3.375d
 			y: 6.75d
 		}
 		{
 			dependencies: [
 				"63CD0236B337EAAD"
-				"5B2696206205CB2E"
+				"713C8D6A20BF3A0E"
 			]
 			description: [
 				"&3Voiding Covers&r can be attached to GregTech Machines, Crates or Drums. They will void stuff you don't want. How fancy!"
@@ -1502,14 +1529,15 @@
 				type: "item"
 			}]
 			title: "Voiding Covers"
-			x: 5.625d
+			x: 4.5d
 			y: 6.75d
 		}
 		{
 			dependencies: [
-				"63CD0236B337EAAD"
 				"581CDF545E1EA1FD"
+				"63CD0236B337EAAD"
 			]
+			dependency_requirement: "one_completed"
 			description: [
 				"&8Wait, we're not in the Steam Age anymore!"
 				""
@@ -1527,8 +1555,8 @@
 				item: "gtceu:lv_extractor"
 				type: "item"
 			}]
-			x: 6.75d
-			y: 6.75d
+			x: 5.625d
+			y: 5.625d
 		}
 		{
 			dependencies: [
@@ -1555,8 +1583,8 @@
 				item: "gtceu:lv_circuit_assembler"
 				type: "item"
 			}]
-			x: 7.875d
-			y: 6.75d
+			x: 5.625d
+			y: 7.875d
 		}
 		{
 			dependencies: ["1A77CA35F054F988"]
@@ -1566,6 +1594,7 @@
 				"You can use it to make easier &aWrought Iron&r, double your &aGlass&r, and gain access to &aAnnealed Copper&r."
 				""
 				"It can also recycle various components and machines back to their original material."
+				""
 				"{@pagebreak}"
 				"&l&3Lore:&r&o Previous versions had both the Arc Furnace and the &bPlasma Arc Furnace&f. In that case, why not use one machine for both? Well, that's exactly what we thought - but we ultimately decided to remove one of the two &bplasma&f recipes. And then the other &bplasma&f recipe. "
 				""
@@ -1584,8 +1613,8 @@
 				item: "gtceu:lv_arc_furnace"
 				type: "item"
 			}]
-			x: -2.25d
-			y: 7.875d
+			x: -3.375d
+			y: 6.75d
 		}
 		{
 			dependencies: ["3A8D7FC6F316C38C"]
@@ -1611,26 +1640,29 @@
 				item: "buildinggadgets2:gadget_building"
 				type: "item"
 			}]
-			x: -2.25d
-			y: 6.75d
+			x: 1.65d
+			y: 6.0d
 		}
 		{
 			dependencies: [
-				"5263F866638D875C"
 				"32B08E6F414A00C0"
+				"15928F50AE80A5CF"
 			]
+			dependency_requirement: "one_completed"
 			description: [
 				"You could waste &o&eprecious years of your life&r in EMI looking for the most optimal Oxygen recipe, given the many ways to obtain it. Various minerals will produce it when electrolyzed."
 				""
 				"If only the quest book had more information!"
 				"{@pagebreak}"
-				"Surprise! The best source according to us &7(!)&r is &acentrifuging Air&r after making a &dGas Collector&r, which you might not be able to make just yet. This recipe also gives &aNitrogen&r, which is handy as it can speed up certain &3Electric Blast Furnace&r recipes&r."
+				"The best way to get &bOxygen&r is by electrolyzing &bSilicon Dioxide&r. Silicon Dioxide is obtained from various sources, most notably Glass Dust. We would &chighly&r recommend setting up an automated, passive line of machines for Oxygen via this method! At first, the machines will consume tons of power, but once the machine buffers are filled up, the machines will rarely turn on. "
 				""
-				"The second best source according to us &7(!)&r is &aelectrolyzing Silicon Dioxide&r. Silicon Dioxide is obtained from various sources, such as Glass Dust, Granite Dust and Black Granite Dust."
+				"To figure out how to get renewable Glass for this purpose, check out the relevant quest in the &eRenewables \\& You&r section."
 				"{@pagebreak}"
-				"The third best source according to us &7(!)&r is &aelectrolyzing Water&r. In reality, electrolysis of water is more suitable for &aHydrogen production&r due to the higher energy cost."
+				"Another method is &acentrifuging Air&r after making a &dGas Collector&r, which you might not be able to make just yet. This recipe also gives &aNitrogen&r, which is handy as it can speed up certain &3Electric Blast Furnace&r recipes&r."
 				""
-				"The fourth best source according to us &7(!)&r is &ato not void&r it, EVER! Any Oxygen obtained from any source is worth something and should be stored in Tanks."
+				"Technically, you could source it by &aelectrolyzing Water&r. In reality, electrolysis of water is more suitable for &aHydrogen production&r due to the higher energy cost."
+				""
+				"Try your best not to &cvoid&r Oxygen! This applies to most fluids and chemicals in GregTech, and is a good habit to pick up. The less Oxygen you void, the less energy and time you spend on generating more."
 				""
 				"&eNote:&r Submit a fluid by having it stored in a &lbucket&r in your inventory. Sorry - it's an FTB Quests quirk."
 			]
@@ -1638,15 +1670,15 @@
 			id: "1A77CA35F054F988"
 			shape: "rsquare"
 			size: 0.66d
-			subtitle: "Achtually, it's Dioxygen..."
+			subtitle: "Ackshually, it's Dioxygen..."
 			tasks: [{
 				id: "1F76ED94CDBD13E1"
 				item: "gtceu:oxygen_bucket"
 				type: "item"
 			}]
 			title: "Breath of Fresh Oxygen"
-			x: -1.125d
-			y: 7.875d
+			x: -2.25d
+			y: 6.75d
 		}
 		{
 			dependencies: ["5263F866638D875C"]
@@ -1674,12 +1706,13 @@
 			}]
 			title: "Glued"
 			x: 0.0d
-			y: 7.875d
+			y: 9.0d
 		}
 		{
 			dependencies: [
 				"5263F866638D875C"
 				"257DB4B39B2A928E"
+				"772F7CD63D31966A"
 			]
 			description: [
 				"Many materials going forward cannot be smelted directly from any Ores! They are instead obtained as byproducts from processing of other ores. Gallium and Arsenic are &4among&r these materials."
@@ -1709,7 +1742,7 @@
 				type: "item"
 			}]
 			title: "Gallium Arsenide"
-			x: 1.5d
+			x: 1.125d
 			y: 7.875d
 		}
 		{
@@ -1742,7 +1775,7 @@
 				type: "item"
 			}]
 			x: 3.375d
-			y: 7.875d
+			y: 9.0d
 		}
 		{
 			dependencies: ["63CD0236B337EAAD"]
@@ -1760,6 +1793,8 @@
 				"&6-&r 1k ME Storage component"
 				""
 				"&6-&r ME Chest"
+				""
+				"&bChannels are disabled&r in this modpack, so feel free to put a few ME Chests with 1k Cells side-by-side to increase your storage capacity! You can use an ME Terminal to access all their contents at the same time."
 				"{@pagebreak}"
 				"&9Note:&r This pack includes &5Fluix Crystals&r, but they are generated as a GT material, rather than the default AE2 Fluix Crystals. To get them, put &dFluix Dust&r in the &aAutoclave&r, which is made from &7Certus Quartz Dust&r, &eNether Quartz Dust&o&r and &cRedstone&r in a &aMixer&r. No need to charge the Certus Quartz. It gets... charged in the Mixer... or something like that."
 				"{@pagebreak}"
@@ -1780,8 +1815,8 @@
 				}
 				type: "item"
 			}]
-			shape: "rsquare"
-			size: 0.66d
+			shape: "square"
+			size: 0.75d
 			subtitle: "Time to ditch those chests"
 			tasks: [{
 				id: "2080D5BB367332D3"
@@ -1818,7 +1853,7 @@
 				item: "gtceu:diode"
 				type: "item"
 			}]
-			x: 5.625d
+			x: 3.375d
 			y: 7.875d
 		}
 		{
@@ -1837,6 +1872,7 @@
 				"&6Having this and Aluminium will grant access to MV Machines.&r"
 			]
 			id: "0DBC148D92A9F69F"
+			progression_mode: "linear"
 			rewards: [{
 				count: 4
 				id: "052E7DFC7E0B9EEF"
@@ -1852,8 +1888,8 @@
 				type: "item"
 			}]
 			title: "First MV Circuit!"
-			x: 7.875d
-			y: 7.875d
+			x: 4.5d
+			y: 9.0d
 		}
 		{
 			dependencies: ["2F1CCFEBAB71B1F3"]
@@ -1880,7 +1916,7 @@
 			}]
 			title: "Aluminium Dust"
 			x: -3.375d
-			y: 6.75d
+			y: 5.625d
 		}
 		{
 			dependencies: ["1E9BE8D3F8A602DC"]
@@ -1909,7 +1945,7 @@
 				""
 				"The &3Rock Breaker&r generates different types of igneous Rocks. In order to operate, &9Water&r and &cLava&r (doesn't need to be source blocks) must both be adjacent to it. Those rocks might be pulverized and electrolyzed into certain materials."
 				""
-				"Certain rocks, such as &b&cRed Granite&r, need up to &5EV&r power to generate."
+				"Certain rocks, such as &b&cRed Granite&r, need, at minimum, &5EV&r power to generate."
 				""
 				"&eAny&r Rock Breaker will complete this Quest."
 				"{@pagebreak}"
@@ -2058,7 +2094,7 @@
 				""
 				"&eFish Oil&r can be extracted from Fish, which can be used for &6Bio Diesel&r."
 				""
-				"Get &eany&r tier Fisher to complete this quest. (They only go up to &5EV&r. If you forsee needing enough Fish to justify an &1IV&r or higher Fisher, make a feature request on our GitHub or Discord.)"
+				"Get &eany&r tier Fisher to complete this quest. (They only go up to &5EV&r. If you foresee needing enough Fish to justify an &1IV&r or higher Fisher, make a feature request on our GitHub or Discord.)"
 			]
 			hide_dependency_lines: true
 			icon: "gtceu:lv_fisher"
@@ -2210,6 +2246,8 @@
 				"&9Note 1:&r All Electric Tools have a lot more durability than indicated, as they use Energy to prevent damage from being applied! On top of that, they can be enchanted as Pickaxes can."
 				""
 				"&9Note 2:&r Drills can now be configured to different ranges, not just the maximum or a single block."
+				""
+				"&9Note 3:&r You can now craft electric versions of other tools too! Hooray for less Wire Cutter crafting!"
 				"{@pagebreak}"
 				"&l&3Lore:&r&o Up until GTCEu, Electric tools required Stainless Steel, which locked players out of experiencing their glory until &6HV&f!"
 			]
@@ -2277,8 +2315,8 @@
 				}
 			]
 			title: "Oh Yeah, we Drillin'"
-			x: 5.519855442176862d
-			y: 4.124574829931966d
+			x: 5.94d
+			y: 2.97d
 		}
 		{
 			dependencies: ["648BCF486E16CCB2"]
@@ -2411,7 +2449,7 @@
 			}]
 			title: "I'm Fetching Me Mallet!"
 			x: 8.91d
-			y: 4.29d
+			y: 4.5d
 		}
 		{
 			dependencies: ["648BCF486E16CCB2"]
@@ -2442,8 +2480,24 @@
 				type: "item"
 			}]
 			title: "And they say GregTech is grindy..."
-			x: -1.1012329931972786d
-			y: 2.237499999999997d
+			x: -1.125d
+			y: 2.25d
+		}
+		{
+			dependencies: ["15928F50AE80A5CF"]
+			description: ["&bNitrogen&r is commonly obtained from centrifuging air. It's very useful, speeding up recipes in many multiblocks like the &bElectric Blast Furnace&r and the &6Pyrolyse Oven&r. We would &chighly&r recommend setting up a dedicated passive line to generate Nitrogen!"]
+			id: "7D7A4CC66A3C193F"
+			shape: "rsquare"
+			size: 0.66d
+			subtitle: "Free nitro?"
+			tasks: [{
+				id: "0C95F5A0FEC594A3"
+				item: "gtceu:nitrogen_bucket"
+				type: "item"
+			}]
+			title: "Nitrogen"
+			x: -2.25d
+			y: 7.875d
 		}
 	]
 	subtitle: ["Tame electricity and make your first machines"]

--- a/config/ftbquests/quests/chapters/mv__medium_voltage.snbt
+++ b/config/ftbquests/quests/chapters/mv__medium_voltage.snbt
@@ -85,7 +85,7 @@
 				"{@pagebreak}"
 				"&l&3Lore:&r&o You may recognise Plantballs from IndustrialCraft2! In IC2 Experimental, there was this rather... obscure way to turn Biomass into Biogas for power, which sadly required too much investment to be really worth it."
 			]
-			icon: "gtceu:plant_ball"
+			icon: "gtceu:biomass_bucket"
 			id: "6EB68C28BEE24DEF"
 			rewards: [{
 				id: "55B6D1599E7C55B1"
@@ -105,7 +105,12 @@
 			y: -1.875d
 		}
 		{
+<<<<<<< Updated upstream
 			dependencies: ["648BCF486E16CCB2"]
+=======
+			dependencies: ["74180AC57AE9F0FE"]
+			dependency_requirement: "one_started"
+>>>>>>> Stashed changes
 			description: [
 				"The Brewery can be used to make &aLubricant&r from &aRedstone&r and &aCreosote&r/&aOil&r. Lubricant has some niche uses, namely being used in the &3Cutter&r to significantly reduce the duration of its recipes."
 				""
@@ -123,7 +128,8 @@
 				random_bonus: 31
 				type: "item"
 			}]
-			size: 0.66d
+			shape: "square"
+			size: 0.75d
 			subtitle: "*hic*... *hic*"
 			tasks: [
 				{
@@ -167,8 +173,13 @@
 				type: "item"
 			}]
 			title: "Ethylene"
+<<<<<<< Updated upstream
 			x: 1.125d
 			y: -3.0d
+=======
+			x: 5.625d
+			y: -4.125d
+>>>>>>> Stashed changes
 		}
 		{
 			dependencies: [
@@ -225,11 +236,23 @@
 				}
 			]
 			title: "Naphtha"
+<<<<<<< Updated upstream
 			x: -1.125d
 			y: -4.125d
 		}
 		{
 			dependencies: ["6238B2A7ED1BE5A1"]
+=======
+			x: -4.5d
+			y: -3.0d
+		}
+		{
+			dependencies: [
+				"6238B2A7ED1BE5A1"
+				"035CF39E6CC98B77"
+			]
+			dependency_requirement: "one_completed"
+>>>>>>> Stashed changes
 			description: [
 				"Don't panic! We'll mostly be doing this to get hydrocarbons."
 				""
@@ -243,6 +266,7 @@
 			]
 			icon: "gtceu:severely_steam_cracked_naphtha_bucket"
 			id: "3E2E161F8CE35138"
+			progression_mode: "linear"
 			size: 0.66d
 			subtitle: "Fuel and oil cracking can get complicated..."
 			tasks: [{
@@ -251,7 +275,11 @@
 				type: "item"
 			}]
 			title: "Fuel Cracking"
+<<<<<<< Updated upstream
 			x: 0.0d
+=======
+			x: -4.5d
+>>>>>>> Stashed changes
 			y: -4.125d
 		}
 		{
@@ -358,7 +386,6 @@
 				""
 				"Higher tier Transformers will require &9Coils&r."
 			]
-			hide_dependency_lines: true
 			icon: "gtceu:mv_transformer_1a"
 			id: "6C20A9A64C1BE0BF"
 			size: 0.75d
@@ -369,8 +396,8 @@
 				type: "item"
 			}]
 			title: "Transformers"
-			x: 2.25d
-			y: 1.5d
+			x: 0.0d
+			y: -0.75d
 		}
 		{
 			dependencies: [
@@ -608,7 +635,7 @@
 				type: "item"
 			}]
 			title: "Steel Alloys"
-			x: 1.125d
+			x: 2.25d
 			y: 2.625d
 		}
 		{
@@ -711,8 +738,8 @@
 				type: "item"
 			}]
 			title: "Advanced Cutter"
-			x: 2.25d
-			y: 2.625d
+			x: 3.375d
+			y: 3.75d
 		}
 		{
 			dependencies: [
@@ -833,7 +860,11 @@
 			}]
 			title: "Greenhouse"
 			x: 0.0d
+<<<<<<< Updated upstream
 			y: 2.625d
+=======
+			y: -1.875d
+>>>>>>> Stashed changes
 		}
 		{
 			dependencies: [
@@ -899,7 +930,6 @@
 		{
 			dependencies: [
 				"10FB27DD3C7BEC2F"
-				"75F38905DEA60F15"
 				"1C55AE6AD5BDE304"
 			]
 			description: ["A circuit component that you can now produce thanks to the &3MV Assembler&r and your shiny new &3Kanthal EBF&r."]
@@ -1116,6 +1146,7 @@
 				"4600221BF0A30C3A"
 				"6E9E15DA847DD0A1"
 				"0DE5C3FBC9A6A690"
+				"375684F9CBEF9132"
 			]
 			description: [
 				"&6The best LV Circuits&r! You can start to churn these guys out, as you'll be making them for the rest of the game."
@@ -1143,6 +1174,7 @@
 				"4600221BF0A30C3A"
 				"0DE5C3FBC9A6A690"
 				"6E9E15DA847DD0A1"
+				"375684F9CBEF9132"
 			]
 			description: [
 				"&6The best MV Circuits&r! You will be making these for the remainder of the game."
@@ -1160,8 +1192,8 @@
 				type: "item"
 			}]
 			title: "Best MV Circuits"
-			x: 7.875d
-			y: 1.5d
+			x: 9.0d
+			y: -0.75d
 		}
 		{
 			dependencies: [
@@ -1185,8 +1217,8 @@
 				type: "item"
 			}]
 			title: "First EV Circuits!"
-			x: 7.875d
-			y: 3.75d
+			x: 11.25d
+			y: -0.75d
 		}
 		{
 			dependencies: [
@@ -1196,7 +1228,7 @@
 			description: [
 				"Better &6HV&r Circuits - much &dcheaper&r and easier to make than before."
 				""
-				"You should now be &aready to move on&r to the HV Chapter, unless you're yet to scale up your Power Production."
+				"Before you move on to &6HV&r, scale up your Power Production, and passively automate the most important processes with AE2!"
 			]
 			icon: "gtceu:micro_processor_assembly"
 			id: "5063FDFFBE3E4855"
@@ -1209,19 +1241,17 @@
 				type: "item"
 			}]
 			title: "More HV Circuits"
-			x: 7.875d
-			y: 2.625d
+			x: 10.125d
+			y: -0.75d
 		}
 		{
-			dependencies: [
-				"375684F9CBEF9132"
-				"10FB27DD3C7BEC2F"
-			]
+			dependencies: ["10FB27DD3C7BEC2F"]
 			description: [
 				"A circuit component that you can now produce thanks to the &3MV Assembler&r!"
 				""
 				"Capacitors are commonly used in computers to store information during power failures, amongst many other uses."
 			]
+			hide_dependency_lines: true
 			icon: "gtceu:capacitor"
 			id: "6E9E15DA847DD0A1"
 			shape: "square"
@@ -1233,7 +1263,7 @@
 				type: "item"
 			}]
 			title: "Capacitors"
-			x: 7.875d
+			x: 9.0d
 			y: -1.875d
 		}
 		{
@@ -1257,7 +1287,7 @@
 				random_bonus: 7
 				type: "item"
 			}]
-			size: 0.66d
+			size: 0.75d
 			subtitle: "You're blue now... that's my alloy"
 			tasks: [{
 				id: "15C7369398FAB8DB"
@@ -1265,16 +1295,17 @@
 				type: "item"
 			}]
 			title: "Blue Alloy"
-			x: 6.75d
-			y: 3.75d
+			x: 11.25d
+			y: -1.875d
 		}
 		{
-			dependencies: ["6E9E15DA847DD0A1"]
+			dependencies: ["10FB27DD3C7BEC2F"]
 			description: [
 				"A Circuit Component that you can now make thanks to the &3MV Assembler&r."
 				""
 				"If you want the cheapest recipe, &aNickel-Zinc Ferrite&r is the way to go."
 			]
+			hide_dependency_lines: true
 			icon: "gtceu:inductor"
 			id: "3DFFA8F91452C62A"
 			shape: "square"
@@ -1286,8 +1317,8 @@
 				type: "item"
 			}]
 			title: "Inductors"
-			x: 9.0d
-			y: 0.375d
+			x: 10.125d
+			y: -1.875d
 		}
 		{
 			dependencies: ["6BB98D128822730E"]
@@ -1298,6 +1329,9 @@
 				""
 				"&aPolyethylene (PE)&r is the key to unlocking &6many new things&r. It's commonly used as &dSheets&r, or in &dFluid&r form."
 				""
+				"In addition, some recipes are now more efficient! Check out diodes and machine hulls (both &8LV&r and &bMV&r)."
+				""
+				"{@pagebreak}"
 				"&l&3Lore:&r&o The OreDict and fluid name for Polyethylene in 1.12.2 GTCEu was &bplastic&f, for cross-mod compatibility."
 			]
 			icon: "gtceu:polyethylene_plate"
@@ -1331,8 +1365,14 @@
 			]
 			icon: "ae2:blank_pattern"
 			id: "1C036BCB2C488CFF"
+<<<<<<< Updated upstream
 			size: 0.66d
 			subtitle: "Autocrafting at last!"
+=======
+			shape: "square"
+			size: 0.75d
+			subtitle: "Autocrafting at last! Well...you'll still need silicon ingots first..."
+>>>>>>> Stashed changes
 			tasks: [{
 				id: "032C24CBA8687E72"
 				item: "ae2:blank_pattern"
@@ -1340,7 +1380,7 @@
 			}]
 			title: "Patterns"
 			x: 5.625d
-			y: -4.125d
+			y: -3.0d
 		}
 		{
 			dependencies: ["10FB27DD3C7BEC2F"]
@@ -1373,7 +1413,7 @@
 				""
 				"PVC item pipes also have the &6highest throughput&r available for a while, but most of your setups right now won't need such speed. Still, it's good to keep this knowledge in your pocket."
 				""
-				"&9Pro tip:&r The fluid form of PVC is never used in base GTCEu, so feel free to solidify all of it into sheets."
+				"&9Pro tip:&r The fluid form of PVC is used only in one recipe in base GTCEu, so feel free to solidify all of it into sheets."
 			]
 			icon: "gtceu:polyvinyl_chloride_plate"
 			id: "40408FFD02134148"
@@ -1418,7 +1458,7 @@
 			]
 			title: "Plastic Boards"
 			x: 7.875d
-			y: -3.0d
+			y: -1.875d
 		}
 		{
 			dependencies: [
@@ -1496,8 +1536,13 @@
 				type: "item"
 			}]
 			title: "Sulfuric Acid"
+<<<<<<< Updated upstream
 			x: 1.125d
 			y: -4.125d
+=======
+			x: 4.5d
+			y: -3.0d
+>>>>>>> Stashed changes
 		}
 		{
 			dependencies: [
@@ -1519,7 +1564,8 @@
 			]
 			icon: "gtceu:hydrochloric_acid_bucket"
 			id: "64CACABB48635904"
-			size: 0.66d
+			shape: "square"
+			size: 0.75d
 			subtitle: "You'll need a lot of this!"
 			tasks: [{
 				id: "34147C1DD7B8DE55"
@@ -1527,8 +1573,13 @@
 				type: "item"
 			}]
 			title: "Hydrochloric Acid"
+<<<<<<< Updated upstream
 			x: 3.375d
 			y: -4.125d
+=======
+			x: 2.25d
+			y: -3.0d
+>>>>>>> Stashed changes
 		}
 		{
 			dependencies: [
@@ -1710,11 +1761,19 @@
 				type: "item"
 			}]
 			title: "Fluid Drilling Rigs"
+<<<<<<< Updated upstream
 			x: -1.125d
 			y: 0.375d
 		}
 		{
 			dependencies: ["648BCF486E16CCB2"]
+=======
+			x: -2.25d
+			y: -0.75d
+		}
+		{
+			dependencies: ["74180AC57AE9F0FE"]
+>>>>>>> Stashed changes
 			description: [
 				"Get any kind of &3Pump&r, place it above an Oil spout and... give it some power."
 				""
@@ -1740,7 +1799,8 @@
 			]
 			icon: "gtceu:oil_bucket"
 			id: "0774EC59CD3DD7A5"
-			size: 0.66d
+			shape: "square"
+			size: 0.75d
 			subtitle: "Ever mined into an Oil deposit?"
 			tasks: [
 				{
@@ -1803,11 +1863,19 @@
 				}
 			]
 			title: "US Simulator"
+<<<<<<< Updated upstream
 			x: -1.125d
 			y: -0.75d
 		}
 		{
 			dependencies: ["648BCF486E16CCB2"]
+=======
+			x: -3.375d
+			y: -0.75d
+		}
+		{
+			dependencies: ["74180AC57AE9F0FE"]
+>>>>>>> Stashed changes
 			description: [
 				"Underground, you may come across pure Oilsands ore veins. You can &3centrifuge&r the Dust to get &aOil&r."
 				""
@@ -1829,7 +1897,8 @@
 				random_bonus: 3
 				type: "item"
 			}]
-			size: 0.66d
+			shape: "square"
+			size: 0.75d
 			subtitle: "This quest was sponsored by the US Military"
 			tasks: [
 				{
@@ -1852,16 +1921,28 @@
 				}
 			]
 			title: "America Simulator"
+<<<<<<< Updated upstream
 			x: -2.25d
+=======
+			x: -4.5d
+>>>>>>> Stashed changes
 			y: -0.75d
 		}
 		{
 			dependencies: [
+<<<<<<< Updated upstream
 				"53DC6E32C41C94C3"
 				"6EB68C28BEE24DEF"
 				"0774EC59CD3DD7A5"
 				"575B07D390D9D079"
 				"05ADBAE5B6F38956"
+=======
+				"0774EC59CD3DD7A5"
+				"575B07D390D9D079"
+				"05ADBAE5B6F38956"
+				"37AAB88A9EDCC862"
+				"6EB68C28BEE24DEF"
+>>>>>>> Stashed changes
 			]
 			description: [
 				"Before we start, here's some important information if you're aiming to make Ethylene:"
@@ -1894,8 +1975,8 @@
 				item: "gtceu:basic_electronic_circuit"
 				type: "item"
 			}]
-			shape: "square"
-			size: 0.75d
+			shape: "gear"
+			size: 1.1d
 			subtitle: "The Illusion of Free Choice"
 			tasks: [{
 				id: "685043442271A0D0"
@@ -1919,7 +2000,11 @@
 				type: "item"
 			}]
 			title: "Distillery"
+<<<<<<< Updated upstream
 			x: -1.125d
+=======
+			x: -3.375d
+>>>>>>> Stashed changes
 			y: -1.875d
 		}
 		{
@@ -1985,8 +2070,13 @@
 				type: "item"
 			}]
 			title: "The Church of Benzene"
+<<<<<<< Updated upstream
 			x: -2.25d
 			y: -1.875d
+=======
+			x: -3.375d
+			y: -3.0d
+>>>>>>> Stashed changes
 		}
 		{
 			dependencies: ["6A304E453D74C57C"]
@@ -1999,7 +2089,7 @@
 				""
 				"&aLight Fuel&r is a good &9Power&r option, but there's something even greater... check the Quest to the left."
 			]
-			icon: "gtceu:lightly_hydro_cracked_heavy_fuel_bucket"
+			icon: "gtceu:light_fuel_bucket"
 			id: "61972B16805FC9EE"
 			size: 0.66d
 			subtitle: "Turn up the Lights in here, baby"
@@ -2017,8 +2107,13 @@
 				}
 			]
 			title: "Light Fuel"
+<<<<<<< Updated upstream
 			x: -1.125d
 			y: -3.0d
+=======
+			x: -5.625d
+			y: -1.875d
+>>>>>>> Stashed changes
 		}
 		{
 			dependencies: ["61972B16805FC9EE"]
@@ -2063,8 +2158,13 @@
 				type: "item"
 			}]
 			title: "The Church of Diesel"
+<<<<<<< Updated upstream
 			x: -2.25d
 			y: -3.0d
+=======
+			x: -6.75d
+			y: -1.875d
+>>>>>>> Stashed changes
 		}
 		{
 			dependencies: ["1FFD2242B94A7378"]
@@ -2104,8 +2204,8 @@
 				type: "item"
 			}]
 			title: "Multiple Channel Pipes"
-			x: 4.5d
-			y: -4.125d
+			x: 2.25d
+			y: -1.875d
 		}
 		{
 			dependencies: ["315169840E06110F"]
@@ -2116,7 +2216,8 @@
 			]
 			icon: "gtceu:ilc_chip"
 			id: "6F6D2829FC42F21C"
-			size: 0.66d
+			shape: "square"
+			size: 0.75d
 			subtitle: "I C U"
 			tasks: [
 				{
@@ -2237,8 +2338,13 @@
 				}
 			]
 			title: "Long-Distance Fluids"
+<<<<<<< Updated upstream
 			x: -3.375d
 			y: -0.75d
+=======
+			x: -4.5d
+			y: 0.375d
+>>>>>>> Stashed changes
 		}
 		{
 			dependencies: ["682C26579EDDCA76"]
@@ -2266,8 +2372,8 @@
 				type: "item"
 			}]
 			title: "Travel Anchors"
-			x: 1.125d
-			y: 3.75d
+			x: 2.25d
+			y: 1.5d
 		}
 		{
 			dependencies: [
@@ -2295,8 +2401,13 @@
 				type: "item"
 			}]
 			title: "I Believe I Can Fly"
+<<<<<<< Updated upstream
 			x: -0.5854591836734713d
 			y: -4.789540816326532d
+=======
+			x: -5.625d
+			y: -0.75d
+>>>>>>> Stashed changes
 		}
 		{
 			dependencies: ["75F38905DEA60F15"]
@@ -2380,6 +2491,105 @@
 			x: -1.123469387755101d
 			y: 2.445153061224488d
 		}
+<<<<<<< Updated upstream
+=======
+		{
+			dependencies: ["7567E885B7166603"]
+			description: [
+				"Welcome to your first (of many) forays into &bHydrocarbons&r! You may already know a few of them, like Petrol, Plastic, Alcohol... well, in GregTech, you'll mass-produce many of these things, and more! This topic can be confusing at times, so you'll want to read carefully in order to avoid getting lost in the details. Now..."
+				"{@pagebreak}"
+				"Here in &bMV&r, there are two main goals of working with Hydrocarbons - Power and Plastics. The interesting part is how you'll accomplish this. There are two main paths you can take: &6Petrochemicals&r and &aBiochemicals&r. Both have their pros and cons - Petrochemicals typically provide &9higher yields&r and &benergy-efficiency&r, while Biochemicals are fully &drenewable&r. Your source of Power and Plastics is entirely &bup to you&r."
+				"{@pagebreak}"
+				"Ready to dive in? The &6Petrochemical&r route(s) are to the left of this quest - you've got three options here. For those with green thumbs, the &2Biochemical&r routes are diagonally right. Best of luck!"
+			]
+			icon: "gtceu:polyethylene_nugget"
+			id: "74180AC57AE9F0FE"
+			shape: "square"
+			size: 0.75d
+			subtitle: "Getting industrial"
+			tasks: [{
+				id: "093E71F51E1ECA6F"
+				title: "Hydrocarbons"
+				type: "checkmark"
+			}]
+			x: -1.125d
+			y: -0.75d
+		}
+		{
+			dependencies: ["6A304E453D74C57C"]
+			description: [
+				"If you've tried to distill an Oil into &eLight Fuel, Heavy Fuel&r, etc., you might've realised that you can't. Instead, you've gotten this &6sulfurized&r version of it. How dreadful!"
+				""
+				"To fix this, we'll need to &6desulfurize&r it. Combine whatever you'd like to desulfurize with &9Hydrogen Gas&r in a &3Chemical Reactor&r to produce the pure product, along with a byproduct of &aHydrogen Sulfide&r. What now?"
+				"{@pagebreak}"
+				""
+				"Luckily, &aHydrogen Sulfide&r is perfectly &drecycled&r in an &3Electrolyzer&r."
+				""
+				"To automate this process, simply place your &3Chemical Reactor&r and your &3Electrolyzer&r next to each other. Be sure to &cenable input from the output side&r. We've graciously provided a &3Fluid Filter&r so that your desulfurized prize doesn't go into your Electrolyzer too - remember to set it to filter both input/extract so that the right fluids can flow both ways!"
+				""
+				"{@pagebreak}"
+				"But now, how do we get our refined goodies out of our &3Chemical Reactor&r? This is where the Electric Pump comes in - use it on a different face of the Chemical Reactor and extract your prize!"
+				""
+				"&l&bTip&r&r: You only need two buckets of &9Hydrogen Gas&r. The easiest way of obtaining it is by electrolyzing water. You don't need to mass-produce Hydrogen (yet), don't worry!"
+			]
+			icon: "gtceu:sulfur_dust"
+			id: "5898743D8D6C2690"
+			rewards: [{
+				id: "7252A11E3828603C"
+				item: "gtceu:fluid_filter"
+				type: "item"
+			}]
+			shape: "square"
+			size: 0.75d
+			subtitle: "Waiter! Why is there Sulfur in my soup?"
+			tasks: [{
+				id: "3F4C5D4741ABEE3C"
+				item: "gtceu:hydrogen_bucket"
+				type: "item"
+			}]
+			title: "Desulfurization"
+			x: -4.5d
+			y: -1.875d
+		}
+		{
+			dependencies: ["5898743D8D6C2690"]
+			description: [
+				"Heavy Fuel can be obtained from many sources, but your best bet is distilling it from &eHeavy Oil&r. "
+				""
+				"You could just burn it in a combustion generator now for &9Power&r, but there's something even greater... check the Quest to the left."
+			]
+			id: "035CF39E6CC98B77"
+			progression_mode: "linear"
+			size: 0.666d
+			subtitle: "Things are getting really Heavy around here..."
+			tasks: [{
+				id: "4BA6939D643E63A6"
+				item: "gtceu:heavy_fuel_bucket"
+				type: "item"
+			}]
+			title: "Heavy Fuel"
+			x: -5.625d
+			y: -3.0d
+		}
+		{
+			dependencies: ["53DC6E32C41C94C3"]
+			description: [
+				"This is the main way of getting &9Power&r via the &aBiochemical&r route. Put Logs in the &3Pyrolyse Oven&r for &9Wood Tar&r. The Charcoal you obtain can then be processed in &3Extractors&r for even more &9Wood Tar&r!"
+				""
+				"Check out the Distillation quest to see what you can do with this wondrous substance."
+			]
+			id: "37AAB88A9EDCC862"
+			size: 0.66d
+			tasks: [{
+				id: "7EC058F5FE8478D1"
+				item: "gtceu:wood_tar_bucket"
+				type: "item"
+			}]
+			title: "Wood Tar"
+			x: -2.25d
+			y: -1.875d
+		}
+>>>>>>> Stashed changes
 	]
 	subtitle: ["Venture into petrochemistry and refine electronics"]
 	title: "&bMV&r - Medium Voltage"

--- a/config/ftbquests/quests/chapters/ore_generation.snbt
+++ b/config/ftbquests/quests/chapters/ore_generation.snbt
@@ -66,7 +66,7 @@
 				"{@pagebreak}"
 				"It's a good practice to make &dWaypoints&r to every vein you find, and to label their type. You may want to come back to it several times."
 				""
-				"A typical Ore vein is &d7 blocks&r tall, and ores generate in 4 different patterns:"
+				"A classic Ore vein is &d7 blocks&r tall, and ores generate in 4 different patterns:"
 				"- The &9Top Ore&r generates in the higher 4 layers of the vein."
 				"- The &9Bottom Ore&r generates in the lower 3 layers of the vein."
 				"- The &9Between Ore&r generates in the middle 3 layers of the vein."
@@ -126,6 +126,11 @@
 				"This vein is namely one of the few direct sources of Gold in the overworld."
 				""
 				"There are many other sources of Gold in GregTech, but you will likely see better yields of Gold if you obtain it by processing other resources."
+<<<<<<< Updated upstream
+=======
+				""
+				"Vanadium Magnetite becomes more useful in &bMV&r, when you will centrifuge out the Vanadium within for Vanadium Steel."
+>>>>>>> Stashed changes
 			]
 			icon: "gtceu:magnetite_ore"
 			id: "260E516A219825A2"
@@ -717,7 +722,11 @@
 		}
 		{
 			dependencies: ["41730E340B3D8EDA"]
-			description: ["Your one and only trusty source for Nickel."]
+			description: [
+				"Your one and only trusty source for Nickel."
+				""
+				"Cobalt makes for some pretty decent early-game item pipes too!"
+			]
 			icon: "gtceu:nickel_ore"
 			id: "38C955F6CBDD95BD"
 			size: 0.9d

--- a/config/ftbquests/quests/chapters/steam_age.snbt
+++ b/config/ftbquests/quests/chapters/steam_age.snbt
@@ -54,8 +54,8 @@
 				type: "item"
 			}]
 			title: "No More Penalty"
-			x: -0.09909863945578223d
-			y: -2.260051020408156d
+			x: 0.0d
+			y: -1.98d
 		}
 		{
 			dependencies: ["40DE888E6025C646"]
@@ -88,8 +88,8 @@
 				type: "item"
 			}]
 			title: "Is it a Phantom? Is it an Elytra?"
-			x: 1.9417176870748278d
-			y: -2.5865816326530435d
+			x: 2.5d
+			y: -2.25d
 		}
 		{
 			dependencies: ["40DE888E6025C646"]
@@ -161,8 +161,8 @@
 				type: "item"
 			}]
 			title: "High Pressure"
-			x: -0.1399149659863994d
-			y: -1.4233163265306032d
+			x: 0.0d
+			y: -1.2d
 		}
 		{
 			dependencies: ["03DBF1961AE21C76"]
@@ -221,12 +221,15 @@
 				"With a very small percentage of carbon in its mass, Steel is significantly tougher than Iron or Wrought Iron.&r"
 				""
 				"One &3PBF&r most likely won't cut it moving forwards. Make another one, and you'll effectively halve the time spent waiting for Steel."
+				""
+				"To save the most time, use blocks of &aCoke&r and &eWrought Iron&r - this generates a block of Steel every 270 seconds. Not bad!"
+				""
 				"{@pagebreak}"
 				"Just to check - did you know GregTech multiblocks can &dshare walls&r? This could save you a whole 12 Firebricks for your second PBF. &7There may be more efficient setups, but don't stress out over figuring them out.&r"
 				""
 				"What you &omay&r also do is upgrade to four &3PBFs&r. It just depends on how much time you want to dedicate to resource collection, but more PBFs are always nice. We won't force you to make them, don't worry."
 				""
-				"&9Note:&r The &3PBF&r cannot be (reasonably) automated, but putting blocks of Iron and Coke/Charcoal will guarantee it will run for a long time without needing to be babysat."
+				"&9Note:&r The &3PBF&r cannot be (reasonably) automated, but putting blocks of Iron and Charcoal will guarantee it will run for a long time without needing to be babysat."
 				"{@pagebreak}"
 				"&l&3Lore:&r&o  In GregTech 5, one single Ingot of Steel would take you &d360 seconds&f in the PBF when using Coal or Charcoal! That's over &e6 hours&f for a whole stack! Of course, with 4 PBFs, that would cut it down to &3around 1.5 hours&f."
 				""
@@ -280,7 +283,7 @@
 				""
 				"Additionally, &6Nether Ores are worth two Overworld Ores&r if mined with &3Silk Touch&r. It'd be great if you could craft the book directly, huh? ;)"
 				"{@pagebreak}"
-				"&4Nether&r veins will take more effort to find - and are more dangerous to mine - than &2Overworld&r veins. Keep on top of your mining by using Waypoints."
+				"&4Nether&r veins will take more effort to find - and are more dangerous to mine - than &2Overworld&r veins. Keep on top of your mining by using Waypoints - and remember that veins can be above you as well!"
 				""
 				"If you're yet to transition to &dPeaceful&r, it isn't too late to make the switch! There's no need to bother fighting Ghasts or Blazes in GTCEu."
 				""
@@ -405,7 +408,7 @@
 				type: "item"
 			}]
 			title: "The First of Many Motors"
-			x: 6.75d
+			x: 7.875d
 			y: -1.5d
 		}
 		{
@@ -446,8 +449,8 @@
 				type: "item"
 			}]
 			title: "Greg has struck again"
-			x: 7.875d
-			y: -1.5d
+			x: 9.0d
+			y: 0.75d
 		}
 		{
 			dependencies: ["5DD49D500327A0E2"]
@@ -491,7 +494,13 @@
 				""
 				"&6Small tip for you:&r no need to worry about your base's biome for now, as your boilers will need very little water to keep up."
 				"{@pagebreak}"
+<<<<<<< Updated upstream
 				"The &cOutput Hatch&r is where water will be generated. You can make it face up or down to auto-output water into your pipes. When you reach &7LV&r or &bMV&r, you can use an Output Hatch from either tier to further boost the Pump's output."
+=======
+				"The &cOutput Hatch&r is where water will be generated. You can make it face up or down to auto-output water into your pipes, which can go &ethrough&r the Treated Wood Frames - just place the pipe before you encase it in the frames. "
+				""
+				"When you reach &7LV&r or &bMV&r, you can use an Output Hatch from either tier to further boost the Pump's output."
+>>>>>>> Stashed changes
 				""
 				"&2Reminder:&r Use a Wrench to rotate GregTech blocks (sneak right-click)."
 				""
@@ -504,8 +513,8 @@
 				item: "gtceu:wood_normal_fluid_pipe"
 				type: "item"
 			}]
-			shape: "gear"
-			size: 1.1d
+			shape: "square"
+			size: 0.75d
 			subtitle: "There's no such thing as \"free\" water"
 			tasks: [{
 				id: "03501AB173BA60EE"
@@ -581,11 +590,11 @@
 			subtitle: "The Steam Extractor extracts..."
 			tasks: [{
 				id: "12A46916B1BC17EC"
-				item: "gtceu:lp_steam_extractor"
+				item: "gtceu:hp_steam_extractor"
 				type: "item"
 			}]
 			title: "Steam Extractor"
-			x: 4.5d
+			x: 5.625d
 			y: -0.375d
 		}
 		{
@@ -612,15 +621,14 @@
 				type: "item"
 			}]
 			title: "Sticky Resin"
-			x: 5.625d
-			y: -0.375d
+			x: 7.875d
+			y: 1.875d
 		}
 		{
 			dependencies: [
 				"3144DC68B266730C"
 				"236C886D50A99785"
 				"1436DB89E21264F3"
-				"22997534983F6812"
 			]
 			description: [
 				"Rubber is an excellent insulation material, and that's exactly what it's used for in GTCEu."
@@ -654,7 +662,7 @@
 				}
 			]
 			title: "Rubbering up"
-			x: 6.75d
+			x: 7.875d
 			y: -0.375d
 		}
 		{
@@ -686,7 +694,7 @@
 			}]
 			title: "Electronics #1: Resistors"
 			x: 7.875d
-			y: -0.375d
+			y: 0.75d
 		}
 		{
 			dependencies: ["5DD49D500327A0E2"]
@@ -697,7 +705,7 @@
 				""
 				"Each material has several sizes for Pipes. The bigger the Pipe, the &ahigher&r the throughput, but the more &dexpensive&r the craft. For example, a normal &6Bronze Fluid Pipe&r transfers 120 mB/t. (It also has a 1,200 mB internal buffer!)"
 				""
-				"Get either a Small or Normal &6Bronze Fluid Pipe&r to complete this quest. Both are used in crafting."
+				"Get any &6Bronze Fluid Pipe&r to complete this quest. The &6small&r and &enormal&r ones in particular are used in other recipes as well."
 				"{@pagebreak}"
 				"&aReminder:&r 1 second = 20 ticks... assuming the server isn't lagging."
 				""
@@ -717,12 +725,20 @@
 			size: 0.66d
 			subtitle: "Liquids, gases... we don't discriminate"
 			tasks: [{
-				id: "006E5756DD2CFB97"
+				id: "5953F4446733D908"
 				item: {
 					Count: 1
 					id: "itemfilters:or"
 					tag: {
+						RepairCost: 0
+						display: {
+							Name: "{\"text\":\"Bronze Pipes!\"}"
+						}
 						items: [
+							{
+								Count: 1b
+								id: "gtceu:bronze_tiny_fluid_pipe"
+							}
 							{
 								Count: 1b
 								id: "gtceu:bronze_small_fluid_pipe"
@@ -731,10 +747,17 @@
 								Count: 1b
 								id: "gtceu:bronze_normal_fluid_pipe"
 							}
+							{
+								Count: 1b
+								id: "gtceu:bronze_large_fluid_pipe"
+							}
+							{
+								Count: 1b
+								id: "gtceu:bronze_huge_fluid_pipe"
+							}
 						]
 					}
 				}
-				title: "Bronze Fluid Pipe"
 				type: "item"
 			}]
 			title: "Fluid Pipes"
@@ -763,8 +786,8 @@
 				"&3Note:&r In this modpack, explosions are configured to &cnot&r damage any block or entity, but you'll &dstill lose&r your machine."
 			]
 			id: "5DD49D500327A0E2"
-			shape: "square"
-			size: 0.75d
+			shape: "gear"
+			size: 1.2d
 			subtitle: "Putting the Steam in Steam Age"
 			tasks: [{
 				id: "0F864E85D4956919"
@@ -853,7 +876,7 @@
 				type: "item"
 			}]
 			title: "Electronics #3: Vacuum Tubes"
-			x: 3.375d
+			x: 5.625d
 			y: 0.75d
 		}
 		{
@@ -905,7 +928,7 @@
 				}
 			]
 			title: "Glass, at last!"
-			x: 3.375d
+			x: 4.125d
 			y: -0.375d
 		}
 		{
@@ -933,7 +956,7 @@
 				type: "item"
 			}]
 			title: "Red Alloy"
-			x: 5.625d
+			x: 4.125d
 			y: 0.75d
 		}
 		{
@@ -970,7 +993,7 @@
 				}
 			]
 			shape: "gear"
-			size: 1.5d
+			size: 1.2d
 			subtitle: "Your first &aElectronic Circuit&r!"
 			tasks: [
 				{
@@ -996,7 +1019,7 @@
 				""
 				"To get &dPotin&r, you should start by crafting its &eDust&r form."
 				""
-				"This quest calls for either the small or normal pipe. Get either size to complete it."
+				"Get a &dPotin&r pipe of any size to complete this quest."
 				"{@pagebreak}"
 				"&l&3Lore:&r&o &dPotin Fluid Pipes&f were first seen in &9GT++&f, an addon to GT5, and are a considerable power spike for players in a relatively unknown pack called &4GT:NH&f. We wanted to spread some of that joy."
 				""
@@ -1014,12 +1037,20 @@
 			size: 0.66d
 			subtitle: "...I'm going into battle, and I need only your finest Potin."
 			tasks: [{
-				id: "159D19181DC4DE59"
+				id: "7C0AFE7BBF56CD68"
 				item: {
 					Count: 1
 					id: "itemfilters:or"
 					tag: {
+						RepairCost: 0
+						display: {
+							Name: "{\"text\":\"Potin Pipes!\"}"
+						}
 						items: [
+							{
+								Count: 1b
+								id: "gtceu:potin_tiny_fluid_pipe"
+							}
 							{
 								Count: 1b
 								id: "gtceu:potin_small_fluid_pipe"
@@ -1028,15 +1059,22 @@
 								Count: 1b
 								id: "gtceu:potin_normal_fluid_pipe"
 							}
+							{
+								Count: 1b
+								id: "gtceu:potin_large_fluid_pipe"
+							}
+							{
+								Count: 1b
+								id: "gtceu:potin_huge_fluid_pipe"
+							}
 						]
 					}
 				}
-				title: "Potin Pipes!"
 				type: "item"
 			}]
 			title: "Potin Seller..."
-			x: -1.125d
-			y: 1.875d
+			x: -2.25d
+			y: 0.75d
 		}
 		{
 			dependencies: ["03DBF1961AE21C76"]
@@ -1195,7 +1233,7 @@
 				}
 			]
 			title: "Electronics #2: Circuit Boards"
-			x: 5.625d
+			x: 6.75d
 			y: 1.875d
 		}
 		{
@@ -1364,6 +1402,7 @@
 				tag: { }
 			}
 			id: "7DDCB711526F37A0"
+			progression_mode: "linear"
 			rewards: [{
 				count: 4
 				id: "3463AA941A74C11C"
@@ -1383,8 +1422,8 @@
 				type: "item"
 			}]
 			title: "Portable Cell"
-			x: 4.5d
-			y: 0.75d
+			x: 4.875d
+			y: 1.32d
 		}
 		{
 			dependencies: ["03DBF1961AE21C76"]
@@ -1439,11 +1478,11 @@
 				}
 			]
 			title: "Tool Belt"
-			x: 2.4927380952380958d
-			y: -2.1580102040816165d
+			x: 2.0d
+			y: -2.75d
 		}
 		{
-			dependencies: ["48AED37B4E20A99A"]
+			dependencies: ["5DD49D500327A0E2"]
 			description: [
 				"&3Item Pipes&r are a simple yet effective way to move items around &dinstantly&r, but with throughput limitations."
 				""
@@ -1460,6 +1499,8 @@
 				"Right now, you can use them in combination with &6Hoppers&r, but you will also be able to use them with Conveyor Modules, Output Buses, and machine Auto-Outputs all in the LV age."
 				""
 				"&9Note:&r GT6-style Pipes are &denabled&r. It means that placing Pipes connect them only to the block they were placed against. To open more connections, use your &5Wrench&r on the grid."
+				""
+				"You can also shift-right click with your Wrench to force items to flow in a certain direction. This can help counteract backflow (items being transported in an undesirable direction.) It also prevents the common issue of your &eCoke Oven Hatches&r trying to export charcoal/coke into your hoppers!"
 				""
 				"Get &eany&r of the suggested Item Pipes to complete this quest."
 				"{@pagebreak}"
@@ -1496,7 +1537,7 @@
 				type: "item"
 			}]
 			title: "Item Pipes"
-			x: 3.375d
+			x: -1.125d
 			y: 1.875d
 		}
 		{
@@ -1530,15 +1571,15 @@
 				type: "item"
 			}]
 			title: "Backpacks"
-			x: 4.5d
-			y: 1.875d
+			x: 3.3d
+			y: 1.32d
 		}
 		{
 			dependencies: ["40DE888E6025C646"]
 			description: [
 				"The &3Charcoal Pile Igniter&r is a particularly unique multiblock. You can use it to produce &aCharcoal&r faster than &3Coke Ovens&r, but this comes with the trade-off of &amanual labor&r."
 				"{@pagebreak}"
-				"To operate the Igniter, dig a big pit into the ground - up to &e9x5x9&r blocks in size. Line the floor of the pit with vanilla &aBrick blocks&r, then fill the remaining space entirely with &aLogs&r. After that, &acover the filled pit&r with Grass, Dirt, or other natural groundcover to form a roof. In the layer with the roof, place the Igniter! To start it, light it with &aFlint and Steel&r."
+				"To operate the Igniter, dig a big pit into the ground - up to &e9x9x5&r blocks in size. Line the floor of the pit with vanilla &aBrick blocks&r, then fill the remaining space entirely with &aLogs&r. After that, &esurround the filled pit&r with Grass, Dirt, or other natural grouncover. In the layer with the roof, place the Igniter! To start it, light it with &aFlint and Steel&r."
 				""
 				"Once the process completes, open up the pit for your reward - &aBrittle Charcoal&r. This can be mined with a Shovel (or Spade!), and each block drops 1.4 Charcoal on average. Assuming 1 Log converts into 1 Brittle Charcoal, we're sure you can see the efficiency boost!"
 				"{@pagebreak}"
@@ -1572,8 +1613,8 @@
 				}
 			]
 			title: "Fuel Pit"
-			x: 1.390697278911567d
-			y: -2.9743367346938605d
+			x: 1.2d
+			y: -2.97d
 		}
 		{
 			dependencies: ["40DE888E6025C646"]
@@ -1681,11 +1722,15 @@
 				}
 			]
 			title: "Multiblock Tanks"
-			x: 0.5539625850340073d
-			y: -2.8110714285714167d
+			x: 0.33d
+			y: -2.64d
 		}
 		{
-			dependencies: ["1FFD2242B94A7378"]
+			dependencies: [
+				"1FFD2242B94A7378"
+				"539CF1B85725786D"
+			]
+			dependency_requirement: "one_completed"
 			description: [
 				"Ever wanted your pipes to look &leven&r cooler? Now you can!"
 				""
@@ -1706,8 +1751,8 @@
 				type: "item"
 			}]
 			title: "Aesthetic Ultra"
-			x: -2.1577721088435453d
-			y: 0.7399489795918583d
+			x: -2.25d
+			y: 1.875d
 		}
 	]
 	subtitle: ["Harness the power of Steam and learn the basics"]


### PR DESCRIPTION
Added Hydrocarbon section to MV, in order to reduce confusion and make the biochemical and petrochemical paths more obvious. Changed layout of Steam section to reduce conflicting arrows, and moved Item Pipes to the start with fluid pipes. Changed layout of LV section to reduce conflicting arrows. Also added more info on automating Oxygen and Nitrogen.

Minor Changes:
Layout of HV chapter.
Some quests in Ore Generation now provide more information. Iron quest in Introduction now gives Raw Magnetite instead of Magnetite Ore.