### PR TITLE
Quests changes relating to GT 7.0 

### DIFF
--- a/config/ftbquests/quests/chapters/ev__extreme_voltage.snbt
+++ b/config/ftbquests/quests/chapters/ev__extreme_voltage.snbt
@@ -113,10 +113,7 @@
 			y: 4.5d
 		}
 		{
-			dependencies: [
-				"35E7E45987D9B1F6"
-				"30A6EDDF25A5E5F8"
-			]
+			dependencies: ["35E7E45987D9B1F6"]
 			description: [
 				"Starting from here, you can now craft &dEV&r &3Energy&r and &3Dynamo Hatches&r! In &dEV&r, Energy Hatches now come with 4A, 16A, 32A or even 64A variants!"
 				""

--- a/config/ftbquests/quests/chapters/iv__insane_voltage.snbt
+++ b/config/ftbquests/quests/chapters/iv__insane_voltage.snbt
@@ -39,8 +39,6 @@
 			dependencies: ["7FA0ACB7F161F378"]
 			description: [
 				"If you already made and centrifuged &aRare Earth&r, that's great! If you haven't, you can obtain it as a &9Byproduct&r from various ores, or from centrifuging &dMonazite&r."
-				""
-				"To extract the &aRare Earths&r&r, you should use a &3Centrifuge&r &4as high a tier as possible&r, due to the increased chance of bonus outputs."
 				"{@pagebreak}"
 				"The elements you can obtain are:"
 				""

--- a/config/ftbquests/quests/chapters/tips_and_tricks_2.snbt
+++ b/config/ftbquests/quests/chapters/tips_and_tricks_2.snbt
@@ -364,6 +364,8 @@
 				"Similarly to the Steam Multiblocks - hopefully, you made these! - you're going to need some &3Buses&r if you want to move items in and out."
 				""
 				"For fluids, you'll instead need &3Hatches&r. Higher tiers of &3Hatches/Buses&r have more slots."
+				""
+				"&9Tip:&r You can Sneak + Right Click a placed &3Hatch&r or &3Bus&r to swap its I/O Direction"
 			]
 			icon: "gtceu:lv_input_bus"
 			id: "0C09F89291D29EF8"
@@ -432,7 +434,7 @@
 				type: "checkmark"
 			}]
 			title: "All About the Cleanroom"
-			x: 0.33d
+			x: 0.0d
 			y: 1.98d
 		}
 		{
@@ -458,7 +460,7 @@
 				type: "checkmark"
 			}]
 			title: "Understanding the Assembly Line"
-			x: 1.32d
+			x: 0.99d
 			y: 1.98d
 		}
 		{
@@ -483,7 +485,7 @@
 				title: "Research"
 				type: "checkmark"
 			}]
-			x: 2.31d
+			x: 1.98d
 			y: 1.98d
 		}
 		{
@@ -565,7 +567,7 @@
 				title: "Large Turbine Mechanics"
 				type: "checkmark"
 			}]
-			x: 3.63d
+			x: 3.97d
 			y: 1.98d
 		}
 		{
@@ -585,7 +587,7 @@
 				title: "Gregicality Multiblocks"
 				type: "checkmark"
 			}]
-			x: 4.62d
+			x: 4.95d
 			y: 1.98d
 		}
 		{
@@ -607,7 +609,7 @@
 				type: "checkmark"
 			}]
 			title: "Parallelisation"
-			x: 5.61d
+			x: 5.94d
 			y: 1.98d
 		}
 		{
@@ -739,6 +741,22 @@
 			}]
 			x: 5.94d
 			y: 0.0d
+		}
+		{
+			dependencies: ["5AD9884E7BFB2510"]
+			description: ["Spraying &3Input Buses&r and &3Hatches&r the same colour will treat them as one &3Hatch&r in the &5Multiblock&r. With distinct mode enabled on the &3Buses/Hatches&r, the &5Multiblock&r will only search for a recipe using ingredients from one colour group."]
+			icon: "gtceu:cyan_dye_spray_can"
+			id: "57EC19AF87A32930"
+			size: 0.66d
+			subtitle: "Colour by number multiblocks"
+			tasks: [{
+				id: "5F4FB0D81F0772F9"
+				title: "Coloured Buses"
+				type: "checkmark"
+			}]
+			title: "Coloured Buses"
+			x: 3.0d
+			y: 1.98d
 		}
 	]
 	subtitle: ["For the Modern Minecrafter"]

--- a/config/ftbquests/quests/chapters/tips_and_tricks_2.snbt
+++ b/config/ftbquests/quests/chapters/tips_and_tricks_2.snbt
@@ -578,6 +578,9 @@
 				"They also introduce Machine Modes - depending on the configured machine mode, the Multiblock will use a different recipe type when processing materials. You can change this from the machine GUI by clicking on the Robot Arm button."
 				"{@pagebreak}"
 				"By including Parallel Control Hatches in your Gregicality Multiblocks, you can grant them parallel processing capability. There are 4 tiers of hatch, each further increasing parallel capability by an factor of 4."
+				"{@pagebreak}"
+				"Batch mode can be enabled on a multiblock to merge together an amount of one recipe together into one recipe up to 5 seconds. This does not change the overal speed of one recipe like overclocking but is useful for stopping machine flickering."
+				"This is not strickly gated by Gregicality Multiblocks, but is extremely useful with them. "
 			]
 			icon: "gtceu:mega_blast_furnace"
 			id: "57DE7059D524FAE9"


### PR DESCRIPTION
- Remove dependency on Tungstensteel for EV energy hatch quest
- Remove info about deprecated chance boosting mechanics
- Add quest detaling the new coloured hatch grouping
- Add info about batch mode to the GCYM quest

also fixes #107 


