### PR TITLE
Fix quest bugs and inconsistencies

### DIFF
--- a/config/ftbquests/quests/chapters/ev__extreme_voltage.snbt
+++ b/config/ftbquests/quests/chapters/ev__extreme_voltage.snbt
@@ -785,21 +785,30 @@
 				"7FA0ACB7F161F378"
 			]
 			description: [
-				"Note that in theory, the &3EV Chemical Reactor&r is skippable by using the &3Large Chemical Reactor&r instead, but we're evil enough to force you to make this."
+				"Note that in theory, the &3EV Chemical Reactor&r is skippable by using the &3Large Chemical Reactor&r instead, so feel free to skip this quest."
 				""
 				"&7It's still useful due to its compact size!"
 				""
 				"&8Honestly, if making one of these is a huge problem material-wise, take a look at your infrastructure."
 			]
+			icon: "gtceu:ev_chemical_reactor"
 			id: "7D15EEE81B1A3100"
 			shape: "square"
 			size: 0.75d
 			subtitle: "Chemistry gets even harder"
-			tasks: [{
-				id: "0AF5929611BCDF2C"
-				item: "gtceu:ev_chemical_reactor"
-				type: "item"
-			}]
+			tasks: [
+				{
+					id: "0AF5929611BCDF2C"
+					item: "gtceu:ev_chemical_reactor"
+					optional_task: true
+					type: "item"
+				}
+				{
+					id: "399628027D7438B9"
+					title: "Just let me cook!"
+					type: "checkmark"
+				}
+			]
 			title: "Extreme Chemical Reactions"
 			x: 5.625d
 			y: 5.625d

--- a/config/ftbquests/quests/chapters/hv__high_voltage.snbt
+++ b/config/ftbquests/quests/chapters/hv__high_voltage.snbt
@@ -362,6 +362,7 @@
 			dependencies: [
 				"6975F16F5B50F17F"
 				"16B735F9C391D260"
+				"4AFD3073C731A1E4"
 			]
 			description: [
 				"&bDigital fluid storage&r is pretty cool. Each &b1k ME Fluid Storage Cell&r holds up to &d18 types&r of fluid, and can hold &6over 8,000 buckets&r of a single fluid type! That's more than a &3Super Tank 2&r!"

--- a/config/ftbquests/quests/chapters/hv__high_voltage.snbt
+++ b/config/ftbquests/quests/chapters/hv__high_voltage.snbt
@@ -364,7 +364,7 @@
 				"16B735F9C391D260"
 			]
 			description: [
-				"&bDigital fluid storage&r is pretty cool. Each &b1k ME Fluid Storage Cell&r holds up to &d5 types&r of fluid, and can hold &6over 8,000 buckets&r of those 5 fluid types! That's more than a &3Super Tank 2&r!"
+				"&bDigital fluid storage&r is pretty cool. Each &b1k ME Fluid Storage Cell&r holds up to &d18 types&r of fluid, and can hold &6over 8,000 buckets&r of a single fluid type! That's more than a &3Super Tank 2&r!"
 				""
 				"You may want to &4format&r Fluid Storage Cells to certain types to prevent the network from clogging. Make a &3Cell Workbench&r to do so."
 			]

--- a/config/ftbquests/quests/chapters/iv__insane_voltage.snbt
+++ b/config/ftbquests/quests/chapters/iv__insane_voltage.snbt
@@ -402,6 +402,7 @@
 				"0F192D1F44B9B599"
 				"5CA86A333670A55C"
 				"528CE69DA4358B2E"
+				"7CC40BDAA803D044"
 			]
 			description: [
 				"The &aHPIC&r unlocks &3IV Energy Hatches&r and &3Dynamos&r... You know the drill!"

--- a/config/ftbquests/quests/chapters/luv__ludicrous_voltage.snbt
+++ b/config/ftbquests/quests/chapters/luv__ludicrous_voltage.snbt
@@ -586,18 +586,28 @@
 			id: "00C14E3B8009DF7F"
 			shape: "rsquare"
 			size: 0.66d
-			tasks: [
-				{
-					id: "6733F9F527CA9B29"
-					item: "gtceu:luv_energy_input_hatch"
-					type: "item"
+			subtitle: "When life gives you energy, make more of it"
+			tasks: [{
+				id: "6733F9F527CA9B29"
+				item: {
+					Count: 1
+					id: "itemfilters:or"
+					tag: {
+						items: [
+							{
+								Count: 1b
+								id: "gtceu:luv_energy_input_hatch"
+							}
+							{
+								Count: 1b
+								id: "gtceu:luv_energy_output_hatch"
+							}
+						]
+					}
 				}
-				{
-					id: "6CE9FCCC37446BFD"
-					item: "gtceu:luv_energy_output_hatch"
-					type: "item"
-				}
-			]
+				title: "MORE ENERGY!"
+				type: "item"
+			}]
 			title: "Upgrading your Assembly Line"
 			x: 2.25d
 			y: 2.25d

--- a/config/ftbquests/quests/chapters/luv__ludicrous_voltage.snbt
+++ b/config/ftbquests/quests/chapters/luv__ludicrous_voltage.snbt
@@ -492,6 +492,7 @@
 				""
 				"&oThe &3Fusion Reactor I&f can only run recipes up to a required EU of 160 MEU to start. It will also overclock up to &dLuV&f at best, even if you upgrade to ZPM Hatches, so don't stress over attempting this."
 			]
+			icon: "gtceu:luv_fusion_reactor"
 			id: "546CC03435E763CF"
 			shape: "gear"
 			size: 1.3d

--- a/config/ftbquests/quests/chapters/luv__ludicrous_voltage.snbt
+++ b/config/ftbquests/quests/chapters/luv__ludicrous_voltage.snbt
@@ -496,11 +496,18 @@
 			shape: "gear"
 			size: 1.3d
 			subtitle: "Stellar power"
-			tasks: [{
-				id: "48A4D39ED0E11EBC"
-				item: "gtceu:luv_fusion_reactor"
-				type: "item"
-			}]
+			tasks: [
+				{
+					id: "48A4D39ED0E11EBC"
+					item: "gtceu:luv_fusion_reactor"
+					type: "item"
+				}
+				{
+					id: "3BFD721E6324023E"
+					item: "gtceu:fusion_casing"
+					type: "item"
+				}
+			]
 			title: "Fusion Reactor I"
 			x: 5.625d
 			y: 2.25d

--- a/config/ftbquests/quests/chapters/mv__medium_voltage.snbt
+++ b/config/ftbquests/quests/chapters/mv__medium_voltage.snbt
@@ -131,7 +131,23 @@
 			tasks: [
 				{
 					id: "095C98D86D021B2E"
-					item: "gtceu:lv_brewery"
+					item: {
+						Count: 1
+						id: "itemfilters:or"
+						tag: {
+							items: [
+								{
+									Count: 1b
+									id: "gtceu:lv_brewery"
+								}
+								{
+									Count: 1b
+									id: "gtceu:mv_brewery"
+								}
+							]
+						}
+					}
+					title: "Let them brew!"
 					type: "item"
 				}
 				{

--- a/config/ftbquests/quests/chapters/steam_age.snbt
+++ b/config/ftbquests/quests/chapters/steam_age.snbt
@@ -569,6 +569,7 @@
 				""
 				"You can also process Dirt in the Extractor for &aBones&r, which makes getting &aBone Meal&r a lot easier for Peaceful players."
 			]
+			icon: "gtceu:hp_steam_extractor"
 			id: "1436DB89E21264F3"
 			rewards: [{
 				count: 16
@@ -582,7 +583,23 @@
 			subtitle: "The Steam Extractor extracts..."
 			tasks: [{
 				id: "12A46916B1BC17EC"
-				item: "gtceu:hp_steam_extractor"
+				item: {
+					Count: 1
+					id: "itemfilters:or"
+					tag: {
+						items: [
+							{
+								Count: 1b
+								id: "gtceu:lp_steam_extractor"
+							}
+							{
+								Count: 1b
+								id: "gtceu:hp_steam_extractor"
+							}
+						]
+					}
+				}
+				title: "EXTRActors!"
 				type: "item"
 			}]
 			title: "Steam Extractor"

--- a/config/ftbquests/quests/chapters/uv__ultimate_voltage.snbt
+++ b/config/ftbquests/quests/chapters/uv__ultimate_voltage.snbt
@@ -368,18 +368,28 @@
 			id: "2F2F82D9DE3C798C"
 			shape: "rsquare"
 			size: 0.66d
-			tasks: [
-				{
-					id: "4783D6B309027111"
-					item: "gtceu:uv_energy_input_hatch"
-					type: "item"
+			subtitle: "I will finish this modpack in the next 15 minutes, right?"
+			tasks: [{
+				id: "4783D6B309027111"
+				item: {
+					Count: 1
+					id: "itemfilters:or"
+					tag: {
+						items: [
+							{
+								Count: 1b
+								id: "gtceu:uv_energy_input_hatch"
+							}
+							{
+								Count: 1b
+								id: "gtceu:uv_energy_output_hatch"
+							}
+						]
+					}
 				}
-				{
-					id: "62593894E98AFC45"
-					item: "gtceu:uv_energy_output_hatch"
-					type: "item"
-				}
-			]
+				title: "Look at those..."
+				type: "item"
+			}]
 			title: "Upgrading your Assembly Line III"
 			x: 4.5d
 			y: 0.375d
@@ -416,18 +426,28 @@
 			id: "5570F02C03267B36"
 			shape: "rsquare"
 			size: 0.66d
-			tasks: [
-				{
-					id: "4DF40C8FF003DDC6"
-					item: "gtceu:uhv_energy_input_hatch"
-					type: "item"
+			subtitle: "I HAVE THE POWER!"
+			tasks: [{
+				id: "4DF40C8FF003DDC6"
+				item: {
+					Count: 1
+					id: "itemfilters:or"
+					tag: {
+						items: [
+							{
+								Count: 1b
+								id: "gtceu:uhv_energy_input_hatch"
+							}
+							{
+								Count: 1b
+								id: "gtceu:uhv_energy_output_hatch"
+							}
+						]
+					}
 				}
-				{
-					id: "6E49D6D700F92C39"
-					item: "gtceu:uhv_energy_output_hatch"
-					type: "item"
-				}
-			]
+				title: "Finally!"
+				type: "item"
+			}]
 			title: "Upgrading your Assembly Line for the Last Time"
 			x: 6.75d
 			y: -1.875d

--- a/config/ftbquests/quests/chapters/zpm__zero_point_module.snbt
+++ b/config/ftbquests/quests/chapters/zpm__zero_point_module.snbt
@@ -390,18 +390,28 @@
 			id: "64EA73FAB2A51850"
 			shape: "rsquare"
 			size: 0.75d
-			tasks: [
-				{
-					id: "0B57097F8879481C"
-					item: "gtceu:zpm_energy_input_hatch"
-					type: "item"
+			subtitle: "My precious..."
+			tasks: [{
+				id: "0B57097F8879481C"
+				item: {
+					Count: 1
+					id: "itemfilters:or"
+					tag: {
+						items: [
+							{
+								Count: 1b
+								id: "gtceu:zpm_energy_input_hatch"
+							}
+							{
+								Count: 1b
+								id: "gtceu:zpm_energy_output_hatch"
+							}
+						]
+					}
 				}
-				{
-					id: "2C60B79F78094E6A"
-					item: "gtceu:zpm_energy_output_hatch"
-					type: "item"
-				}
-			]
+				title: "Energy hatches"
+				type: "item"
+			}]
 			title: "Upgrading your Assembly Line II"
 			x: -2.625d
 			y: 2.25d

--- a/index.toml
+++ b/index.toml
@@ -134,7 +134,7 @@ hash = "3de3b8987fbd6652079f9a6f8ff7f0d140753eb94563b31554648a09990d89e1"
 
 [[files]]
 file = "config/ftbquests/quests/chapters/hv__high_voltage.snbt"
-hash = "c412eacca0e03c6dd9c979d9bca0d3c98fa8cb35613ce8268f4f783934212b47"
+hash = "0cc52881d1c7794bdda09fec3cf8948a367b48069c3c968579625e4db587c3ce"
 
 [[files]]
 file = "config/ftbquests/quests/chapters/iv__insane_voltage.snbt"

--- a/index.toml
+++ b/index.toml
@@ -142,7 +142,7 @@ hash = "3e8d67a0e489ad0c423fa452dc7cc5c7f7b2033e737cd9a841d79964856c28af"
 
 [[files]]
 file = "config/ftbquests/quests/chapters/luv__ludicrous_voltage.snbt"
-hash = "58c00008efc0b0fb54f3c997b6c164045509e2b681aa20c95f67212253b75fc8"
+hash = "29cbf9f550ed34c192c2c35f118b0f646bd2b0677eba4f5b332ae8feb807348a"
 
 [[files]]
 file = "config/ftbquests/quests/chapters/lv__low_voltage.snbt"

--- a/index.toml
+++ b/index.toml
@@ -138,7 +138,7 @@ hash = "0cc52881d1c7794bdda09fec3cf8948a367b48069c3c968579625e4db587c3ce"
 
 [[files]]
 file = "config/ftbquests/quests/chapters/iv__insane_voltage.snbt"
-hash = "3e8d67a0e489ad0c423fa452dc7cc5c7f7b2033e737cd9a841d79964856c28af"
+hash = "eedd222cbfc9dba18f26292b1abefacccfce90abe526cad1c0ada44ab55ab57e"
 
 [[files]]
 file = "config/ftbquests/quests/chapters/luv__ludicrous_voltage.snbt"

--- a/index.toml
+++ b/index.toml
@@ -186,7 +186,7 @@ hash = "8095cd533cc73a8c978732d07017080d3a73a7f016ef4d59db5473c60027974e"
 
 [[files]]
 file = "config/ftbquests/quests/chapters/zpm__zero_point_module.snbt"
-hash = "7fb0ab7a9aadbad7563ecfac1cedf3204a70761abb5b93df84f77f3a7504ceba"
+hash = "07fdeecd23d0f1d4d2ede235a58ad40868b3cf1d75997d332179733f11eeb79c"
 
 [[files]]
 file = "config/ftbquests/quests/data.snbt"

--- a/index.toml
+++ b/index.toml
@@ -154,7 +154,7 @@ hash = "c597f716bb540288bd909925586087298edabb66bf5b65b8f353631f05e295ce"
 
 [[files]]
 file = "config/ftbquests/quests/chapters/mv__medium_voltage.snbt"
-hash = "a56548786776759e435b6e7a77a4da2ac285c2fe7fae7886a74d19140f9ff217"
+hash = "439c1a06a0a4d801176d7f712047038b61cfc8351c3da9757844d174bba13bcc"
 
 [[files]]
 file = "config/ftbquests/quests/chapters/ore_generation.snbt"

--- a/index.toml
+++ b/index.toml
@@ -174,7 +174,7 @@ hash = "070e4c59640dc3014745eb4f2b83f918342a92c7dbec9a44c7e003500de90904"
 
 [[files]]
 file = "config/ftbquests/quests/chapters/steam_age.snbt"
-hash = "77232cec33203139fb43919eccdb092da49d10875094453644d41ccadb7a932a"
+hash = "8fedd17037d8b8b607a16ad905f9f55571c67211b177bc0ca783518c0790408a"
 
 [[files]]
 file = "config/ftbquests/quests/chapters/tips_and_tricks_2.snbt"

--- a/index.toml
+++ b/index.toml
@@ -1,6 +1,10 @@
 hash-format = "sha256"
 
 [[files]]
+file = "AI_POLICY.md"
+hash = "26e36ab96e9f0d7d38a3b1a4996b734d7eb55ce2ebfa3c704829cd67a740080a"
+
+[[files]]
 file = "LICENSE"
 hash = "7ffe1954587c77dfba1cf8eb9b2ea743671fa6e63f9e7a2f258119d42e14eefe"
 
@@ -130,7 +134,7 @@ hash = "3de3b8987fbd6652079f9a6f8ff7f0d140753eb94563b31554648a09990d89e1"
 
 [[files]]
 file = "config/ftbquests/quests/chapters/hv__high_voltage.snbt"
-hash = "5c2fe63f75cc01610eeef47184f35b6d1438295dd02a27b0a9bc894e61735ec8"
+hash = "c412eacca0e03c6dd9c979d9bca0d3c98fa8cb35613ce8268f4f783934212b47"
 
 [[files]]
 file = "config/ftbquests/quests/chapters/iv__insane_voltage.snbt"

--- a/index.toml
+++ b/index.toml
@@ -142,7 +142,7 @@ hash = "3e8d67a0e489ad0c423fa452dc7cc5c7f7b2033e737cd9a841d79964856c28af"
 
 [[files]]
 file = "config/ftbquests/quests/chapters/luv__ludicrous_voltage.snbt"
-hash = "833e906ad614f3e1c3ea7e589e0db89c23c8021b2e8c4b867a91c955fb3015bf"
+hash = "58c00008efc0b0fb54f3c997b6c164045509e2b681aa20c95f67212253b75fc8"
 
 [[files]]
 file = "config/ftbquests/quests/chapters/lv__low_voltage.snbt"

--- a/index.toml
+++ b/index.toml
@@ -182,7 +182,7 @@ hash = "efa0f2b09438b9ccd5bc7ac1629f9ee21d6bb24db62ebcc1c365335ff6305576"
 
 [[files]]
 file = "config/ftbquests/quests/chapters/uv__ultimate_voltage.snbt"
-hash = "29cbbea672860c7c190eecdcfe8d9b183017a1c68b517b84c02675c0f8380f30"
+hash = "8095cd533cc73a8c978732d07017080d3a73a7f016ef4d59db5473c60027974e"
 
 [[files]]
 file = "config/ftbquests/quests/chapters/zpm__zero_point_module.snbt"

--- a/index.toml
+++ b/index.toml
@@ -142,7 +142,7 @@ hash = "3e8d67a0e489ad0c423fa452dc7cc5c7f7b2033e737cd9a841d79964856c28af"
 
 [[files]]
 file = "config/ftbquests/quests/chapters/luv__ludicrous_voltage.snbt"
-hash = "29cbf9f550ed34c192c2c35f118b0f646bd2b0677eba4f5b332ae8feb807348a"
+hash = "8ca5d01352839456f01fd8aad8a88580b70cbddd34c912f2b3d559bde9a3bfda"
 
 [[files]]
 file = "config/ftbquests/quests/chapters/lv__low_voltage.snbt"

--- a/index.toml
+++ b/index.toml
@@ -122,7 +122,7 @@ hash = "cc7b7524a1409711280d59e9af31b93d161cb654981abb0b2ea945111734fd3d"
 
 [[files]]
 file = "config/ftbquests/quests/chapters/ev__extreme_voltage.snbt"
-hash = "d0c6552030a59ae11105d9de2e75e393ab8a589afb4610019705483a6144ae25"
+hash = "e897a99eea742c08aa21488a6a6df4877c0aff460475720e8c093982c1b5cd9b"
 
 [[files]]
 file = "config/ftbquests/quests/chapters/gtceu.snbt"

--- a/pack.toml
+++ b/pack.toml
@@ -6,7 +6,7 @@ pack-format = "packwiz:1.1.0"
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "9b65ccc87bffecd997c0abf334cd31db5269abe47d68df4b73815a016efcbebc"
+hash = "2e22de7d9fb866e7e88ad76e71744159f24ce45dba1f24a01c98212c1ca4258e"
 
 [versions]
 forge = "47.4.10"

--- a/pack.toml
+++ b/pack.toml
@@ -6,7 +6,7 @@ pack-format = "packwiz:1.1.0"
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "f15f0d0eaa18bb74f35c7f9769965b019227a79a436e088adbd8bd6f669721ff"
+hash = "fb1694c06c91fb7d765c31e8ccdc177c51740b2fe89d551582a13294dc493682"
 
 [versions]
 forge = "47.4.10"

--- a/pack.toml
+++ b/pack.toml
@@ -6,7 +6,7 @@ pack-format = "packwiz:1.1.0"
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "1290976f42976d9ddc6a3a7e41631aa84aed1ced5a00baf1c3ed751882e9b826"
+hash = "a1bee6f07931b4f561f624ad3785da1a9074cac312e30eddc90a84cd869d63b6"
 
 [versions]
 forge = "47.4.10"

--- a/pack.toml
+++ b/pack.toml
@@ -6,7 +6,7 @@ pack-format = "packwiz:1.1.0"
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "a1bee6f07931b4f561f624ad3785da1a9074cac312e30eddc90a84cd869d63b6"
+hash = "6c18d4296fd01d55d6f1f2159e70b42515db0f5526791e43823aa6a6654897a3"
 
 [versions]
 forge = "47.4.10"

--- a/pack.toml
+++ b/pack.toml
@@ -6,7 +6,7 @@ pack-format = "packwiz:1.1.0"
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "2e22de7d9fb866e7e88ad76e71744159f24ce45dba1f24a01c98212c1ca4258e"
+hash = "f15f0d0eaa18bb74f35c7f9769965b019227a79a436e088adbd8bd6f669721ff"
 
 [versions]
 forge = "47.4.10"

--- a/pack.toml
+++ b/pack.toml
@@ -6,7 +6,7 @@ pack-format = "packwiz:1.1.0"
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "435050c1d4ae67e4ff5e697557fb2174cf8c4d0321bace1cf419d4fcfc931286"
+hash = "b8e14db7d6abeb44c15061e2382cd041ab2ca8f61164fd0340a86a5cb3a2ed7f"
 
 [versions]
 forge = "47.4.10"

--- a/pack.toml
+++ b/pack.toml
@@ -6,7 +6,7 @@ pack-format = "packwiz:1.1.0"
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "83d1158b6d139f1c58228ef5cba3c783fb0a3d9b978b38ff36d5baef5dff3b71"
+hash = "2c5452312301acdf8d9b3d9f10d9d585e7af04cbb5a5e807664dd8d4267b5e26"
 
 [versions]
 forge = "47.4.10"

--- a/pack.toml
+++ b/pack.toml
@@ -6,7 +6,7 @@ pack-format = "packwiz:1.1.0"
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "6c18d4296fd01d55d6f1f2159e70b42515db0f5526791e43823aa6a6654897a3"
+hash = "93bd31e60e444ab20b623c6f610fc5b38339430fd76807f4f0ca65e46f134582"
 
 [versions]
 forge = "47.4.10"

--- a/pack.toml
+++ b/pack.toml
@@ -6,7 +6,7 @@ pack-format = "packwiz:1.1.0"
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "2c5452312301acdf8d9b3d9f10d9d585e7af04cbb5a5e807664dd8d4267b5e26"
+hash = "9b65ccc87bffecd997c0abf334cd31db5269abe47d68df4b73815a016efcbebc"
 
 [versions]
 forge = "47.4.10"

--- a/pack.toml
+++ b/pack.toml
@@ -6,7 +6,7 @@ pack-format = "packwiz:1.1.0"
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "fb1694c06c91fb7d765c31e8ccdc177c51740b2fe89d551582a13294dc493682"
+hash = "1290976f42976d9ddc6a3a7e41631aa84aed1ced5a00baf1c3ed751882e9b826"
 
 [versions]
 forge = "47.4.10"

--- a/pack.toml
+++ b/pack.toml
@@ -6,7 +6,7 @@ pack-format = "packwiz:1.1.0"
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "93bd31e60e444ab20b623c6f610fc5b38339430fd76807f4f0ca65e46f134582"
+hash = "435050c1d4ae67e4ff5e697557fb2174cf8c4d0321bace1cf419d4fcfc931286"
 
 [versions]
 forge = "47.4.10"


### PR DESCRIPTION
## Summary

This pull request fixes most bugs or inconsistencies described in #191, and what I've found myself. Closes #188. Here is the list of changes:

1. Steam extractor quest now uses OR filter and allows for submission of low pressure steam extractor.
2. EV chemical reactor can be skipped with checkmark.
3. MV Brewery quest now has OR filter and allows for MV brewery (wow).
4. LuV, ZPM, UV "upgrading your assembly line" quests now allow for submitting either input or output energy hatches. I've also added some fun subtitles to them that were previously missing 😸 
5. Added fusion machine casing requirement for LuV fusion reactor quest. I've never built a fusion reactor myself, so I don't know the optimal material-wise structure for the fusion reactor 1, so I've just added a single casing. Maybe if someone knows the optimal build - we can list the exact number of casings and hatches, like we did in the Cleanroom quest for its respective components.
6. Updated description and dependencies of "Digital Fluid Storage" quest. Previously it said that fluid cells could contain only 5 types, but in the current version they can store up to 18, also I changed the wording for "8000 buckets", saying that only a single type of fluid can contain this number in 1k fluid storage cell. Finally, I've added dependency on EV circuit for this quest because you cannot craft the cell without it, which misled me in my playthrough.
7. Added IV cutting machine dependency for HPIC quest in IV

## Testing

- I've exported the pack with packwiz export functionality and tested the quests I've changed.
- I've used packwiz refresh after any changes to .snbt files.

# Comments

I am currently in HV, and I do not have much experience with GT, so I have not understood some takes on ammonia quest "wack requiremeents" :smile:  and IV cutting machine dependency for HPIC (I have not found its usage in crafting). Feel free to give comments, will be glad to hear any of them!